### PR TITLE
YUKONAEMF-69: remove core-forms-components-examples packages

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -88,18 +88,6 @@
                             <artifactId>core-forms-components-af-core</artifactId>
                             <target>/apps/yukon-forms-vendor-packages/application/install</target>
                         </embedded>
-                                                                  <embedded>
-                        <groupId>com.adobe.aem</groupId>
-                        <artifactId>core-forms-components-examples-apps</artifactId>
-                        <type>zip</type>
-                        <target>/apps/yukon-forms-vendor-packages/application/install</target>
-                      </embedded>
-                      <embedded>
-                        <groupId>com.adobe.aem</groupId>
-                        <artifactId>core-forms-components-examples-content</artifactId>
-                        <type>zip</type>
-                        <target>/apps/yukon-forms-vendor-packages/application/install</target>
-                      </embedded>
                                           </embeddeds>
                 </configuration>
             </plugin>
@@ -239,15 +227,5 @@
           <groupId>com.adobe.aem</groupId>
           <artifactId>core-forms-components-af-core</artifactId>
         </dependency>
-            <dependency>
-        <groupId>com.adobe.aem</groupId>
-        <artifactId>core-forms-components-examples-apps</artifactId>
-        <type>zip</type>
-      </dependency>
-      <dependency>
-        <groupId>com.adobe.aem</groupId>
-        <artifactId>core-forms-components-examples-content</artifactId>
-        <type>zip</type>
-      </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -555,18 +555,6 @@ Bundle-DocURL:
         <artifactId>core-forms-components-af-core</artifactId>
         <version>${core.forms.components.af.version}</version>
       </dependency>
-      <dependency>
-        <groupId>com.adobe.aem</groupId>
-        <artifactId>core-forms-components-examples-apps</artifactId>
-        <type>zip</type>
-        <version>${core.forms.components.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.adobe.aem</groupId>
-        <artifactId>core-forms-components-examples-content</artifactId>
-        <type>zip</type>
-        <version>${core.forms.components.version}</version>
-      </dependency>
       <!-- Testing -->
       <dependency>
         <groupId>org.junit</groupId>


### PR DESCRIPTION
Remove `core-forms-components-examples*` packages from dependencies, as they depend on the previously removed `core.wcm.components.examples*` packages, causing a build error during deployment