### PR TITLE
eServices - Persist form state across different languages (production)

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/js.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/js.txt
@@ -7,5 +7,6 @@ matomoScript.js
 phnValidation.js
 validateDateByDaysPassed.js
 setFeedbackLinkParameters.js
+setLanguageLinkParameters.js
 triggerPerPanelValidation.js
 

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/js/setLanguageLinkParameters.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/js/setLanguageLinkParameters.js
@@ -1,0 +1,56 @@
+/**
+ * Adds the form's guide state to local storage so that it can be restored later.
+ */
+function addStateToSessionStorage() {
+	if (!window.guideBridge) {
+		console.error("Guide bridge object not found.");
+		return;
+	}
+	window.guideBridge.getGuideState({
+		success: function (guideResultObj) {
+			var jsonData = guideResultObj.data;
+			var jsonString = JSON.stringify(jsonData.guideState);
+			localStorage.setItem("previousLanguageState", jsonString);
+		},
+		error: function (guideResultObj) {
+			console.error("Unable to fetch guide state. Proceeding without restoring state.");
+		}
+	});
+}
+
+/**
+ * Attempts to load the form's guide state from local storage. If found, the object is then removed (as it will become out of date).
+ */
+function loadStateFromSessionStorage() {
+	if (!window.guideBridge) {
+		console.error("Guide bridge object not found.");
+		return;
+	}
+	var previousLanguageState = localStorage.getItem("previousLanguageState");	
+	if (previousLanguageState) {
+		window.guideBridge.restoreGuideState({
+			guideState: JSON.parse(previousLanguageState),
+			error: function (guideResultObj) {
+				console.error("Unable to restore guide state.");
+			}
+		});
+		localStorage.removeItem("previousLanguageState");
+		console.debug("Loaded and removed previous guide state from storage.");
+	} else {
+		console.debug("No previous language state found.");
+	}
+}
+	
+/**
+ * Changes 'click' event of switch language links such that form state is migrated across different versions of it.
+ */
+document.addEventListener("DOMContentLoaded", function () {
+    loadStateFromSessionStorage();
+    var links = document.querySelectorAll("footer + .link a");
+    for (var i=0; i<links.length; i++) {
+	    links[i].addEventListener("click", function (e) {
+		    addStateToSessionStorage();
+	    });
+    }
+});
+


### PR DESCRIPTION
As of now, when the user selects "English" or "Français" to access the same form in a different language, all the information they had entered is lost. This PR addresses that by saving the form state to local storage and loading it when the user clicks on one of the language links.