### PR TITLE
eServices - Fix styling of checkboxes and radio buttons on Safari

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/less/style.less
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/less/style.less
@@ -23,3 +23,9 @@ a {
         color: @link-text-color-visited;
     }
 }
+
+.macSafariForm .guideFieldWidget input[type="checkbox"], .macSafariForm .guideFieldWidget input[type="radio"] {
+	height: 20px;
+	float: none;
+}
+


### PR DESCRIPTION
On Safari, checkboxes and radio buttons were smaller and misaligned with the labels. This PR fixes that by overriding the default CSS rules that cause that on Safari.