### PR TITLE
allow guideTextDraw element as firstFillableField

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/js/triggerPerPanelValidation.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/js/triggerPerPanelValidation.js
@@ -32,7 +32,8 @@ var getFirstFillableField = function getFirstFillableField(parentPanel) {
 	parentPanel.visit(function (cmp) {
 		if (cmp.className !== 'guidePanel'
 			&& cmp.className !== 'guideInstanceManager'
-			&& cmp.className !== 'guideTextDraw'
+			// note: can add this back when viewport math with cmp elements doesn't cause errors 
+			// && cmp.className !== 'guideTextDraw'
 			&& cmp.className !== 'guideButton'
 			&& cmp.enabled === true
 			&& cmp.visible


### PR DESCRIPTION
Context:
With the current `getFirstFillableField` implementation, we exclude `guideTextDraw` elements so that we call `setFocus` on only the first fillable field in a given panel when it loads (i.e. going from one panel to the next). This causes an issue when the panel has a large amount of text at the top, as the panel will automatically set focus on the first fillable element, scrolling past all the text at the top. 

https://github.com/user-attachments/assets/f18f26df-dd59-441f-92dd-3619822c22f5

Fix: 
I tried implementing viewport math (`querySelector`, `getBoundingClientRect`) with the cmp elements in a given panel to conditionally set the focus only if the first fillable element is within the viewport when the panel is scrolled to the top on load, but calling `getBoundingClientRect` with cmp elements was causing errors. Given the urgent nature of the requested fix and the expected solution of scrolling to the top of each panel on load, I've commented out the line that excludes `guideTextDraw` from the first fillable field. Finding a viewport solution to maintain setting the focus on the first fillable element is worth investigating in the future. 

https://github.com/user-attachments/assets/e53bc4e1-cd56-44ba-8c1b-89c58c41eb14