### PR TITLE
Add Expand and Collapse All Buttons to Repeatable Panels

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/panelcontainer/clientlibs/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/panelcontainer/clientlibs/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    allowProxy="{Boolean}true"
+    categories="[yukon-forms.components]"/>

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/panelcontainer/clientlibs/js.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/panelcontainer/clientlibs/js.txt
@@ -1,0 +1,19 @@
+###############################################################################
+# Copyright 2022 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+#base=js
+
+panel.js

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/panelcontainer/clientlibs/js/panel.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/panelcontainer/clientlibs/js/panel.js
@@ -26,8 +26,8 @@ function setAccordion(accordionEl, expand) {
 }
 
 document.addEventListener('click', (e) => {
-  const expandBtn = e.target.closest('[aria-label="Expand All"]') || e.target.closest('[aria-label="Tout afficher"]');
-  const collapseBtn = e.target.closest('[aria-label="Collapse All"]') || e.target.closest('[aria-label="Masquer"]');
+  const expandBtn = e.target.closest('.expandAllPanelsButton');
+  const collapseBtn = e.target.closest('.collapseAllPanelsButton');
   
   const clicked = expandBtn || collapseBtn;
   if (!clicked) return;
@@ -65,8 +65,8 @@ document.addEventListener('click', (e) => {
 
   // Check if a sibling expand/collapse button exists
   const hasManagedButton = accordionWrapper.parentElement?.querySelector(
-    '[aria-label="Expand All"], [aria-label="Collapse All"], ' +
-    '[aria-label="Tout afficher"], [aria-label="Masquer"]'
+    '.expandAllPanelsButton, ' +
+    '.collapseAllPanelsButton'
   );
 
   // If no expand/collapse button nearby, let AEM handle it normally

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/panelcontainer/clientlibs/js/panel.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/panelcontainer/clientlibs/js/panel.js
@@ -1,6 +1,6 @@
 function setAccordion(accordionEl, expand) {
   // Get all child panels
-  const panels = accordionEl.querySelectorAll('[data-guide-parent-id]');
+  const panels = accordionEl.querySelectorAll(':scope > [data-guide-parent-id]');
 
   panels.forEach(panel => {
     const btn = panel.querySelector('[aria-expanded]');
@@ -26,8 +26,8 @@ function setAccordion(accordionEl, expand) {
 }
 
 document.addEventListener('click', (e) => {
-  const expandBtn = e.target.closest('[aria-label="Expand All"]');
-  const collapseBtn = e.target.closest('[aria-label="Collapse All"]');
+  const expandBtn = e.target.closest('[aria-label="Expand All"]') || e.target.closest('[aria-label="Tout afficher"]');
+  const collapseBtn = e.target.closest('[aria-label="Collapse All"]') || e.target.closest('[aria-label="Masquer"]');
   
   const clicked = expandBtn || collapseBtn;
   if (!clicked) return;
@@ -55,11 +55,27 @@ document.addEventListener('click', (e) => {
   const toggle = e.target.closest('[data-guide-toggle="accordion-tab"]');
   if (!toggle) return;
 
-  // Stop AEM's listener from firing
+  // Find the .accordion-navigators this toggle belongs to
+  const accordionNav = toggle.closest('.accordion-navigators');
+  if (!accordionNav) return;
+
+  // Walk up to the outermost guide-item wrapper that contains this accordion
+  const accordionWrapper = accordionNav.closest('[data-guide-parent-id]');
+  if (!accordionWrapper) return;
+
+  // Check if a sibling expand/collapse button exists
+  const hasManagedButton = accordionWrapper.parentElement?.querySelector(
+    '[aria-label="Expand All"], [aria-label="Collapse All"], ' +
+    '[aria-label="Tout afficher"], [aria-label="Masquer"]'
+  );
+
+  // If no expand/collapse button nearby, let AEM handle it normally
+  if (!hasManagedButton) return;
+
+  // Otherwise, stop AEM's listener from firing
   e.stopPropagation();
   e.preventDefault();
 
-  // Find the panel this header belongs to
   const panel = toggle.closest('[data-guide-parent-id]');
   if (!panel) return;
 

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/panelcontainer/clientlibs/js/panel.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/panelcontainer/clientlibs/js/panel.js
@@ -49,3 +49,37 @@ document.addEventListener('click', (e) => {
     sibling = sibling.nextElementSibling;
   }
 });
+
+// Replace AEM's built-in panel header functionality to work with our expand/collapse all
+document.addEventListener('click', (e) => {
+  const toggle = e.target.closest('[data-guide-toggle="accordion-tab"]');
+  if (!toggle) return;
+
+  // Stop AEM's listener from firing
+  e.stopPropagation();
+  e.preventDefault();
+
+  // Find the panel this header belongs to
+  const panel = toggle.closest('[data-guide-parent-id]');
+  if (!panel) return;
+
+  const btn = panel.querySelector('[aria-expanded]');
+  const content = panel.querySelector('.afAccordionPanel');
+  const isExpanded = btn?.getAttribute('aria-expanded') === 'true';
+
+  if (isExpanded) {
+    panel.classList.remove('active');
+    if (btn) {
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-pressed', 'false');
+    }
+    if (content) content.style.display = 'none';
+  } else {
+    panel.classList.add('active');
+    if (btn) {
+      btn.setAttribute('aria-expanded', 'true');
+      btn.setAttribute('aria-pressed', 'true');
+    }
+    if (content) content.style.display = '';
+  }
+}, true);

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/panelcontainer/clientlibs/js/panel.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/panelcontainer/clientlibs/js/panel.js
@@ -1,0 +1,22 @@
+function setAllAccordions(expand) {
+  document.querySelectorAll('.accordion').forEach(accordion => {
+    console.debug('in function, accordion:', accordion)
+    accordion.querySelectorAll('[aria-expanded]').forEach(btn => {
+      const isExpanded = btn.getAttribute('aria-expanded') === 'true';
+      if (expand && !isExpanded) btn.click();
+      if (!expand && isExpanded) btn.click();
+    });
+  });
+}
+
+// TODO: fix click mechanism
+document.addEventListener('click', (e) => {
+  if (e.target.closest('[name="expandAllBtn"]')) {
+    console.debug('set to true');
+    setAllAccordions(true);
+  }
+  if (e.target.closest('[name="collapseAllBtn"]')) {
+    console.debug('set to false');
+    setAllAccordions(false);
+  }
+})

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/panelcontainer/clientlibs/js/panel.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/panelcontainer/clientlibs/js/panel.js
@@ -1,22 +1,51 @@
-function setAllAccordions(expand) {
-  document.querySelectorAll('.accordion').forEach(accordion => {
-    console.debug('in function, accordion:', accordion)
-    accordion.querySelectorAll('[aria-expanded]').forEach(btn => {
-      const isExpanded = btn.getAttribute('aria-expanded') === 'true';
-      if (expand && !isExpanded) btn.click();
-      if (!expand && isExpanded) btn.click();
-    });
+function setAccordion(accordionEl, expand) {
+  // Get all child panels
+  const panels = accordionEl.querySelectorAll('[data-guide-parent-id]');
+
+  panels.forEach(panel => {
+    const btn = panel.querySelector('[aria-expanded]');
+    const content = panel.querySelector('.afAccordionPanel');
+
+    if (expand) {
+      panel.classList.add('active');
+      if (btn) {
+        btn.setAttribute('aria-expanded', 'true');
+        btn.setAttribute('aria-pressed', 'true');
+      }
+      if (content) content.style.display = '';
+    } 
+    else {
+      panel.classList.remove('active');
+      if (btn) {
+        btn.setAttribute('aria-expanded', 'false');
+        btn.setAttribute('aria-pressed', 'false');
+      }
+      if (content) content.style.display = 'none';
+    }
   });
 }
 
-// TODO: fix click mechanism
 document.addEventListener('click', (e) => {
-  if (e.target.closest('[name="expandAllBtn"]')) {
-    console.debug('set to true');
-    setAllAccordions(true);
+  const expandBtn = e.target.closest('[aria-label="Expand All"]');
+  const collapseBtn = e.target.closest('[aria-label="Collapse All"]');
+  
+  const clicked = expandBtn || collapseBtn;
+  if (!clicked) return;
+
+  const expand = !!expandBtn;
+
+  // Walk up to the outermost guide-item wrapper
+  const buttonWrapper = clicked.closest('[data-guide-parent-id]');
+  if (!buttonWrapper) return;
+
+  // The accordion is in a sibling div, find the next sibling that contains .accordion-navigators
+  let sibling = buttonWrapper.nextElementSibling;
+  while (sibling) {
+    const accordion = sibling.querySelector('.accordion-navigators');
+    if (accordion) {
+      setAccordion(accordion, expand);
+      return;
+    }
+    sibling = sibling.nextElementSibling;
   }
-  if (e.target.closest('[name="collapseAllBtn"]')) {
-    console.debug('set to false');
-    setAllAccordions(false);
-  }
-})
+});


### PR DESCRIPTION
On repeatable panels with the accordion layout, we needed a mechanism to expand and collapse all the panels when there is more than 1 panel. Implemented clientlib JS code wired to "Expand All" and "Collapse All" buttons and their sibling accordion/repeatable panel. Also added a stopPropagation/preventDefault when the panel headers are clicked, as AEM's default open/close functionality was not working properly with our expand/collapse buttons. 

https://github.com/user-attachments/assets/0c145671-75c4-4988-a5b3-d01b3a64f69c