### PR TITLE
replace syntax to fix error on rule editor

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/panelcontainer/clientlibs/js/panel.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/panelcontainer/clientlibs/js/panel.js
@@ -1,10 +1,10 @@
 function setAccordion(accordionEl, expand) {
   // Get all child panels
-  const panels = accordionEl.querySelectorAll(':scope > [data-guide-parent-id]');
+  var panels = accordionEl.querySelectorAll(':scope > [data-guide-parent-id]');
 
-  panels.forEach(panel => {
-    const btn = panel.querySelector('[aria-expanded]');
-    const content = panel.querySelector('.afAccordionPanel');
+  panels.forEach(function(panel) {
+    var btn = panel.querySelector('[aria-expanded]');
+    var content = panel.querySelector('.afAccordionPanel');
 
     if (expand) {
       panel.classList.add('active');
@@ -25,23 +25,23 @@ function setAccordion(accordionEl, expand) {
   });
 }
 
-document.addEventListener('click', (e) => {
-  const expandBtn = e.target.closest('.expandAllPanelsButton');
-  const collapseBtn = e.target.closest('.collapseAllPanelsButton');
+document.addEventListener('click', function(e) {
+  var expandBtn = e.target.closest('.expandAllPanelsButton');
+  var collapseBtn = e.target.closest('.collapseAllPanelsButton');
   
-  const clicked = expandBtn || collapseBtn;
+  var clicked = expandBtn || collapseBtn;
   if (!clicked) return;
 
-  const expand = !!expandBtn;
+  var expand = !!expandBtn;
 
   // Walk up to the outermost guide-item wrapper
-  const buttonWrapper = clicked.closest('[data-guide-parent-id]');
+  var buttonWrapper = clicked.closest('[data-guide-parent-id]');
   if (!buttonWrapper) return;
 
   // The accordion is in a sibling div, find the next sibling that contains .accordion-navigators
-  let sibling = buttonWrapper.nextElementSibling;
+  var sibling = buttonWrapper.nextElementSibling;
   while (sibling) {
-    const accordion = sibling.querySelector('.accordion-navigators');
+    var accordion = sibling.querySelector('.accordion-navigators');
     if (accordion) {
       setAccordion(accordion, expand);
       return;
@@ -51,37 +51,37 @@ document.addEventListener('click', (e) => {
 });
 
 // Replace AEM's built-in panel header functionality to work with our expand/collapse all
-document.addEventListener('click', (e) => {
-  const toggle = e.target.closest('[data-guide-toggle="accordion-tab"]');
+document.addEventListener('click', function(e) {
+  var toggle = e.target.closest('[data-guide-toggle="accordion-tab"]');
   if (!toggle) return;
 
   // Find the .accordion-navigators this toggle belongs to
-  const accordionNav = toggle.closest('.accordion-navigators');
+  var accordionNav = toggle.closest('.accordion-navigators');
   if (!accordionNav) return;
 
   // Walk up to the outermost guide-item wrapper that contains this accordion
-  const accordionWrapper = accordionNav.closest('[data-guide-parent-id]');
+  var accordionWrapper = accordionNav.closest('[data-guide-parent-id]');
   if (!accordionWrapper) return;
 
   // Check if a sibling expand/collapse button exists
-  const hasManagedButton = accordionWrapper.parentElement?.querySelector(
+  var hasManagedButton = accordionWrapper.parentElement ? accordionWrapper.parentElement.querySelector(
     '.expandAllPanelsButton, ' +
     '.collapseAllPanelsButton'
-  );
+  ) : null;
 
-  // If no expand/collapse button nearby, let AEM handle it normally
+  // If no expand/collapse button nearby, var AEM handle it normally
   if (!hasManagedButton) return;
 
   // Otherwise, stop AEM's listener from firing
   e.stopPropagation();
   e.preventDefault();
 
-  const panel = toggle.closest('[data-guide-parent-id]');
+  var panel = toggle.closest('[data-guide-parent-id]');
   if (!panel) return;
 
-  const btn = panel.querySelector('[aria-expanded]');
-  const content = panel.querySelector('.afAccordionPanel');
-  const isExpanded = btn?.getAttribute('aria-expanded') === 'true';
+  var btn = panel.querySelector('[aria-expanded]');
+  var content = panel.querySelector('.afAccordionPanel');
+  var isExpanded = btn && btn.getAttribute('aria-expanded') === 'true';
 
   if (isExpanded) {
     panel.classList.remove('active');


### PR DESCRIPTION
No logic changes, just replaced syntax that was likely causing the error in the Rule Editor: 
- replaced `const` and `let` with `var`
- replaced `=>` with `function()`
- replaced `?` with explicit null checks

The error seems to have stopped popping up after these changes when I test it locally, but we'll have to try it on the cloud by deploying to dev. 