### PR TITLE
add remove button to eventListener

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/panelcontainer/clientlibs/js/panel.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/panelcontainer/clientlibs/js/panel.js
@@ -52,6 +52,9 @@ document.addEventListener('click', function(e) {
 
 // Replace AEM's built-in panel header functionality to work with our expand/collapse all
 document.addEventListener('click', function(e) {
+  // Allow the remove button to work normally
+  if (e.target.closest('[data-guide-addremove="remove"]')) return;
+
   var toggle = e.target.closest('[data-guide-toggle="accordion-tab"]');
   if (!toggle) return;
 


### PR DESCRIPTION
Added a check for the remove button to the accordion/repeatable panel header event listener, skips the logic if the user is clicking the remove button.

Note: removing panels does not rename the panels (see screen recording for an example). This is an item of work that is already listed in the upcoming things to fix, so it will be fixed separately.

https://github.com/user-attachments/assets/3df9558f-2cb5-4f9b-89c3-3426e01e7329
