### PR TITLE
eServices - Adapt repeatable helpers client library to make it callable from AEM rules

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-utils/js/repeatableHelpers.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-utils/js/repeatableHelpers.js
@@ -174,7 +174,7 @@ Convenience function that gets, filters, and formats repeatable panel data in on
 function getFilteredFormattedData(containerName, repeatableName, fieldNamesCsv, filterField, filterOperator, filterValue, itemTemplate, separator) {
 
     var data = getDataFromRepeatablePanel(containerName, repeatableName, fieldNamesCsv);
-    if (filterField) {
+    if (filterField.trim()) {
         data = filterData(data, filterField, filterOperator, filterValue);
     }
     return formatData(data, itemTemplate, separator);


### PR DESCRIPTION
It is not possible to enter an empty string (or null) through the Author interface. However, the "getFilteredFormattedData" relied on one of its arguments to be an empty string (or falsy) so that filtering would be skipped. This PR addresses that by trimming the argument before it is evaluated. That means the user can pass a single space to the function and it's going to be evaluated as an empty string.