### PR TITLE
eServices - Add mechanism for overriding behaviour of accordion delete button (production)

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/panelcontainer/clientlibs/js/panel.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/panelcontainer/clientlibs/js/panel.js
@@ -52,14 +52,28 @@ document.addEventListener('click', function(e) {
 
 // Replace AEM's built-in panel header functionality to work with our expand/collapse all
 document.addEventListener('click', function(e) {
-  // Allow the remove button to work normally
-  if (e.target.closest('[data-guide-addremove="remove"]')) return;
 
   var toggle = e.target.closest('[data-guide-toggle="accordion-tab"]');
   if (!toggle) return;
 
+  var tab = e.target.closest('.accordion-navigators > div');
+  if (!tab) return;
+
+  // Allow the remove button to work normally
+  if (e.target.closest('[data-guide-addremove="remove"]')) {
+    // Check for a control button, in which case, use that instead of the default remove button
+    var removeControl = tab.querySelector('.removeAccordionControl button');
+    if (!removeControl) {
+      return;
+    }
+    e.stopPropagation();
+    e.preventDefault();
+    removeControl.click();
+    return;
+  }
+
   // Find the .accordion-navigators this toggle belongs to
-  var accordionNav = toggle.closest('.accordion-navigators');
+  var accordionNav = tab.closest('.accordion-navigators');
   if (!accordionNav) return;
 
   // Walk up to the outermost guide-item wrapper that contains this accordion


### PR DESCRIPTION
Sometimes we want some custom logic to run before an accordion item is deleted. That is not possible out-of-the-box with the trash can button, as AEM doesn't let us modify it. This PR implements a workaround in which clicking on the button triggers a second button (likely hidden, and identified by the class 'removeAccordionControl'), if present. The Forms Designer is then able to add all the pre-removal logic to that button.