### PR TITLE
eServices - Re-enable focus on first fillable field (production)

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/js/triggerPerPanelValidation.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/js/triggerPerPanelValidation.js
@@ -32,8 +32,7 @@ var getFirstFillableField = function getFirstFillableField(parentPanel) {
 	parentPanel.visit(function (cmp) {
 		if (cmp.className !== 'guidePanel'
 			&& cmp.className !== 'guideInstanceManager'
-			// note: can add this back when viewport math with cmp elements doesn't cause errors 
-			// && cmp.className !== 'guideTextDraw'
+			&& cmp.className !== 'guideTextDraw'
 			&& cmp.className !== 'guideButton'
 			&& cmp.enabled === true
 			&& cmp.visible
@@ -54,12 +53,13 @@ var getFirstFillableField = function getFirstFillableField(parentPanel) {
  * Scrolls to the top of the page and looks for a fillable field. 
  */
 var setFocusToFirstFillableField = function setFocusToFirstFillableField(guide, panel) {
-	window.scrollTo(0, 0);
 	var firstFillableField = getFirstFillableField(panel);
 	if (firstFillableField) {
 		guide.setFocus(firstFillableField);
+		window.scrollTo(0, 0);
 		return true;
 	}
+	window.scrollTo(0, 0);
 	return false;
 };
 


### PR DESCRIPTION
Previously, we disabled setting focus to the first fillable field upon navigating to a page using the Next or Previous buttons as that was causing an issue with the "Time for response" page. As that page has now been refactored such that setting focus to the first fillable field would no longer cause any issues, this PR re-enables it.