### PR TITLE
eServices - Navigation fixes (dev)

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/js/triggerPerPanelValidation.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/js/triggerPerPanelValidation.js
@@ -241,13 +241,19 @@ document.addEventListener('DOMContentLoaded', function() {
  * Enables refocus for tabs.
  */
 document.addEventListener('DOMContentLoaded', function() {
-	var tabs = document.querySelectorAll('a.guideLeftNavIcon');
+	var tabs = document.querySelectorAll('ul.tab-navigators-vertical > li');
 	for (var i = 0; i < tabs.length; i++) {
 		tabs[i].addEventListener('click', function(e) {
 			if (window.formState) {
 				window.formState.ignoreRefocus = false;
 			}
 		});
+
+		tabs[i].addEventListener('keydown', function(e) {
+			if (e.code === "Space") {
+				window.formState.ignoreRefocus = false;
+			}
+		}, true);
 	}
 });
 

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/less/style.less
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/less/style.less
@@ -33,4 +33,8 @@ a {
 	display: none !important;
 }
 
+ul.tab-navigators-vertical > li:focus-visible {
+	z-index: 1000;
+	position: relative;
+}
 


### PR DESCRIPTION
- Adds keydown event and replaces target of click event on left tabs with li elements (previously, it was the anchor, which didn't work consistently)
- Adjusts the styling of left tabs (when focused by keyboard) such that the outline is not overlapped by the tab further down 