### PR TITLE
eServices - Navigation fixes (production)

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/js/triggerPerPanelValidation.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/js/triggerPerPanelValidation.js
@@ -52,12 +52,43 @@ var getFirstFillableField = function getFirstFillableField(parentPanel) {
 };
 
 /**
+ * Finds the first text draw element of a panel
+ */
+var getFirstTextDraw = function getFirstTextDraw(parentPanel) {
+	if (parentPanel === null || parentPanel === undefined) {
+		console.debug('No parent panel found.');
+		return null;
+	}
+	var firstTextDraw = null;
+	parentPanel.visit(function (cmp) {
+		if (cmp.className === 'guideTextDraw'
+			&& cmp.visible
+		) {
+			if (firstTextDraw === null) {
+				console.debug('Found first text draw.');
+				firstTextDraw = cmp.somExpression;
+				return;
+			}
+			console.debug('First text draw already found.');
+			return;
+		}
+	});
+	return firstTextDraw;
+};
+
+/**
  * Scrolls to the top of the page and looks for a fillable field. 
  */
 var setFocusToFirstFillableField = function setFocusToFirstFillableField(guide, panel) {
 	var firstFillableField = getFirstFillableField(panel);
 	if (firstFillableField) {
 		guide.setFocus(firstFillableField);
+		window.scrollTo(0, 0);
+		return true;
+	}
+	var firstTextDraw = getFirstTextDraw(panel);
+	if (firstTextDraw) {
+		guide.setFocus(firstTextDraw);
 		window.scrollTo(0, 0);
 		return true;
 	}

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/js/triggerPerPanelValidation.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/js/triggerPerPanelValidation.js
@@ -241,13 +241,19 @@ document.addEventListener('DOMContentLoaded', function() {
  * Enables refocus for tabs.
  */
 document.addEventListener('DOMContentLoaded', function() {
-	var tabs = document.querySelectorAll('a.guideLeftNavIcon');
+	var tabs = document.querySelectorAll('ul.tab-navigators-vertical > li');
 	for (var i = 0; i < tabs.length; i++) {
 		tabs[i].addEventListener('click', function(e) {
 			if (window.formState) {
 				window.formState.ignoreRefocus = false;
 			}
 		});
+
+		tabs[i].addEventListener('keydown', function(e) {
+			if (e.code === "Space") {
+				window.formState.ignoreRefocus = false;
+			}
+		}, true);
 	}
 });
 

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/js/triggerPerPanelValidation.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/js/triggerPerPanelValidation.js
@@ -1,6 +1,8 @@
 window.formState = {
 	wasOnStartPage: true,
-	wasOnFinishPage: false
+	wasOnFinishPage: false,
+	// toolbar buttons have their own focus logic, so we ignore focusing when the navigation changes
+	ignoreRefocus: true,
 };
 
 /**
@@ -173,6 +175,14 @@ document.addEventListener('DOMContentLoaded', function() {
 			console.error("Error while resolving active panel: ".concat(e.message));
 		}
 	});
+
+	// Set focus to first fillable field for tabs
+	window.guideBridge.on("elementNavigationChanged", function(_e, payload) {
+		if (window.formState && !window.formState.ignoreRefocus) {
+			setFocusToFirstFillableField(window.guideBridge, payload.target);
+			window.formState.ignoreRefocus = true;
+		}
+	});
 });
 
 /**
@@ -194,5 +204,19 @@ document.addEventListener('DOMContentLoaded', function() {
 			setFocusToFirstFillableField(window.guideBridge, activePanel);
 		}
 	});
+});
+
+/**
+ * Enables refocus for tabs.
+ */
+document.addEventListener('DOMContentLoaded', function() {
+	var tabs = document.querySelectorAll('a.guideLeftNavIcon');
+	for (var i = 0; i < tabs.length; i++) {
+		tabs[i].addEventListener('click', function(e) {
+			if (window.formState) {
+				window.formState.ignoreRefocus = false;
+			}
+		});
+	}
 });
 

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/js/triggerPerPanelValidation.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/js/triggerPerPanelValidation.js
@@ -251,3 +251,14 @@ document.addEventListener('DOMContentLoaded', function() {
 	}
 });
 
+/**
+ * Ensures that focus is set to the next item when the user uses the scribble signature field.
+ */
+document.addEventListener('DOMContentLoaded', function() {
+        window.guideBridge.on("elementValueChanged", function(event, payload) {
+                if (payload.target.className === "guideScribble") {
+                        console.debug("Target was a scribble signature field. Setting focus to next item in the panel.");
+                        window.guideBridge.setFocus(payload.target.parent.navigationContext.nextItem);
+                }
+        });
+});

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/less/style.less
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/less/style.less
@@ -33,4 +33,8 @@ a {
 	display: none !important;
 }
 
+ul.tab-navigators-vertical > li:focus-visible {
+	z-index: 1000;
+	position: relative;
+}
 


### PR DESCRIPTION
- Adds focus to first fillable field mechanism to tabs
- Fixes lost focus after using the scribble signature component
- Adds fallback to text draw when fillable fields are absent (e.g. start page)
- Adjusts the styling of left tabs (when focused by keyboard) such that the outline is not overlapped by the tab further down