### PR TITLE
add dynamic signatures

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -153,5 +153,11 @@ Import-Package: javax.annotation;version=0.0.0,*
             <version>1.4.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/core/src/main/java/ca/yukon/aem/core/forms/model/Signer.java
+++ b/core/src/main/java/ca/yukon/aem/core/forms/model/Signer.java
@@ -1,0 +1,96 @@
+package ca.yukon.aem.core.forms.model;
+
+import java.util.Objects;
+
+/**
+ * Represents a single signer extracted from a repeatable panel in an
+ * AEM Adaptive Form submission.
+ *
+ * <p>Each signer maps to one participant in the resulting Adobe Sign
+ * agreement and (optionally) one signature field on the Document of
+ * Record PDF.</p>
+ */
+public class Signer {
+
+    private final String name;
+    private final String email;
+    private final String role;
+    private final Integer signaturePage;
+    private final Integer signatureX;
+    private final Integer signatureY;
+
+    public Signer(String name, String email, String role,
+                  Integer signaturePage, Integer signatureX, Integer signatureY) {
+        this.name = name;
+        this.email = email;
+        this.role = role;
+        this.signaturePage = signaturePage;
+        this.signatureX = signatureX;
+        this.signatureY = signatureY;
+    }
+
+    public Signer(String name, String email) {
+        this(name, email, "SIGNER", null, null, null);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    /**
+     * Adobe Sign participant role. Common values: SIGNER, APPROVER,
+     * FORM_FILLER, DELEGATE_TO_SIGNER. Defaults to SIGNER.
+     */
+    public String getRole() {
+        return role == null ? "SIGNER" : role;
+    }
+
+    /**
+     * 1-based page number where this signer's signature field should be
+     * placed on the DoR PDF. Null means use the configured default.
+     */
+    public Integer getSignaturePage() {
+        return signaturePage;
+    }
+
+    /**
+     * X coordinate (in PDF points) for the signature field. Null means
+     * the field will be placed at the field's anchor or skipped.
+     */
+    public Integer getSignatureX() {
+        return signatureX;
+    }
+
+    /**
+     * Y coordinate (in PDF points) for the signature field.
+     */
+    public Integer getSignatureY() {
+        return signatureY;
+    }
+
+    public boolean isValid() {
+        return email != null && !email.trim().isEmpty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Signer)) return false;
+        Signer s = (Signer) o;
+        return Objects.equals(email, s.email) && Objects.equals(name, s.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, email);
+    }
+
+    @Override
+    public String toString() {
+        return "Signer{name='" + name + "', email='" + email + "', role='" + getRole() + "'}";
+    }
+}

--- a/core/src/main/java/ca/yukon/aem/core/forms/model/package-info.java
+++ b/core/src/main/java/ca/yukon/aem/core/forms/model/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+package ca.yukon.aem.core.forms.model;

--- a/core/src/main/java/ca/yukon/aem/core/forms/services/AdobeSignService.java
+++ b/core/src/main/java/ca/yukon/aem/core/forms/services/AdobeSignService.java
@@ -1,0 +1,85 @@
+package ca.yukon.aem.core.forms.services;
+
+import ca.yukon.aem.core.forms.model.Signer;
+import org.apache.sling.api.resource.ResourceResolver;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+/**
+ * Service that creates Adobe Sign agreements with a dynamic number of
+ * signers.
+ *
+ * <p>This is the public abstraction used by workflow steps. The
+ * implementation handles transient document upload, agreement creation,
+ * dynamic participant placement, and dynamic signature field placement
+ * via the Adobe Sign v6 REST API.</p>
+ *
+ * <h2>Credentials resolution</h2>
+ * <p>Each method takes a {@code cloudConfigPath} pointing to an AEM Adobe
+ * Sign Cloud Service config (e.g.
+ * {@code /conf/yukon-forms/settings/cloudconfigs/adobesign/<configName>/jcr:content}).
+ * When provided (non-empty), the implementation reads the access token,
+ * API endpoint and sender email from that JCR node. Different workflows
+ * can target different cloud configs by passing a different path.</p>
+ *
+ * <p>When {@code cloudConfigPath} is null or empty, the implementation
+ * falls back to explicit credentials in the OSGi configuration. This is
+ * useful for local development.</p>
+ */
+public interface AdobeSignService {
+
+    /**
+     * Upload a document to Adobe Sign as a transient document.
+     *
+     * @param fileName        display name of the document (e.g. "petition.pdf")
+     * @param mimeType        MIME type (e.g. "application/pdf")
+     * @param fileContent     file contents
+     * @param resolver        resolver used to read the cloud config node
+     *                        when {@code cloudConfigPath} is set; may be
+     *                        null when OSGi fallback supplies credentials
+     * @param cloudConfigPath JCR path to the AEM Adobe Sign Cloud Service
+     *                        config; may be null/empty to use OSGi fallback
+     * @return transient document id (valid for 7 days)
+     * @throws IOException on network or API error
+     */
+    String uploadTransientDocument(String fileName, String mimeType,
+                                   InputStream fileContent,
+                                   ResourceResolver resolver,
+                                   String cloudConfigPath) throws IOException;
+
+    /**
+     * Create an Adobe Sign agreement with one participant per signer.
+     *
+     * <p>Each signer is a separate participantSet with the same order
+     * (parallel signing). A signature field is placed for each signer.</p>
+     *
+     * @param agreementName   visible name of the agreement
+     * @param transientDocId  returned from {@link #uploadTransientDocument}
+     * @param signers         non-empty list of signers
+     * @param message         optional message included in signing emails
+     * @param resolver        see param of {@link #uploadTransientDocument}
+     * @param cloudConfigPath see param of {@link #uploadTransientDocument}
+     * @return Adobe Sign agreement id
+     * @throws IOException              on network or API error
+     * @throws IllegalArgumentException if no valid signers are supplied
+     */
+    String createAgreement(String agreementName, String transientDocId,
+                           List<Signer> signers, String message,
+                           ResourceResolver resolver,
+                           String cloudConfigPath) throws IOException;
+
+    /**
+     * Retrieve the current status of an agreement.
+     *
+     * @param agreementId     Adobe Sign agreement id
+     * @param resolver        see param of {@link #uploadTransientDocument}
+     * @param cloudConfigPath see param of {@link #uploadTransientDocument}
+     * @return status string returned by the API (e.g. OUT_FOR_SIGNATURE)
+     * @throws IOException on network or API error
+     */
+    String getAgreementStatus(String agreementId,
+                              ResourceResolver resolver,
+                              String cloudConfigPath) throws IOException;
+}

--- a/core/src/main/java/ca/yukon/aem/core/forms/services/impl/AdobeSignServiceImpl.java
+++ b/core/src/main/java/ca/yukon/aem/core/forms/services/impl/AdobeSignServiceImpl.java
@@ -4,14 +4,11 @@ import ca.yukon.aem.core.forms.model.Signer;
 import ca.yukon.aem.core.forms.services.AdobeSignService;
 import com.adobe.granite.crypto.CryptoException;
 import com.adobe.granite.crypto.CryptoSupport;
+import com.google.gson.Gson;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
-import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +22,8 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -81,7 +80,6 @@ public class AdobeSignServiceImpl implements AdobeSignService {
     private static final String[] CLOUD_REFRESH_TOKEN_KEYS = {"refresh_token", "refreshToken"};
     private static final String[] CLOUD_TOKEN_URI_KEYS     = {"access_token_uri", "accessTokenUri", "tokenEndpoint"};
     private static final String[] CLOUD_BASEURL_KEYS       = {"api_access_point", "apiAccessPoint", "baseUrl", "baseURL"};
-    private static final String[] CLOUD_SENDER_KEYS        = {"senderEmail", "sender_email", "userEmail"};
 
     @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
     private volatile CryptoSupport cryptoSupport;
@@ -93,6 +91,11 @@ public class AdobeSignServiceImpl implements AdobeSignService {
     protected void activate() {
         LOG.info("AdobeSignService activated. Credentials are resolved per-call from " +
                 "an AEM Adobe Sign Cloud Service config (cloudConfigPath workflow arg).");
+    }
+
+    @Deactivate
+    protected void deactivate() {
+        tokenCache.clear();
     }
 
     @Override
@@ -410,7 +413,7 @@ public class AdobeSignServiceImpl implements AdobeSignService {
 
     private static String urlEncode(String s) {
         try {
-            return URLEncoder.encode(s, "UTF-8");
+            return URLEncoder.encode(s, StandardCharsets.UTF_8);
         } catch (Exception e) {
             return s;
         }
@@ -422,63 +425,58 @@ public class AdobeSignServiceImpl implements AdobeSignService {
 
     String buildAgreementPayload(String agreementName, String transientDocId,
                                  List<Signer> signers, String message) {
-        StringBuilder sb = new StringBuilder(1024);
-        sb.append('{');
+        AgreementPayload payload = new AgreementPayload();
+        payload.fileInfos = Collections.singletonList(new FileInfo(transientDocId));
+        payload.name = agreementName;
+        payload.signatureType = "ESIGN";
+        payload.state = "IN_PROCESS";
+        payload.message = (message != null && !message.isEmpty()) ? message : null;
+        payload.participantSetsInfo = buildParticipantSets(signers);
+        payload.formFieldLayerTemplates = Collections.emptyList();
+        payload.formFields = buildFormFields(signers);
+        return new Gson().toJson(payload);
+    }
 
-        sb.append("\"fileInfos\":[{\"transientDocumentId\":\"")
-                .append(jsonEscape(transientDocId)).append("\"}],");
+    private List<ParticipantSet> buildParticipantSets(List<Signer> signers) {
+        List<ParticipantSet> sets = new ArrayList<>();
+        for (Signer s : signers) {
+            MemberInfo member = new MemberInfo();
+            member.email = s.getEmail();
+            member.name = (s.getName() != null && !s.getName().isEmpty()) ? s.getName() : null;
 
-        sb.append("\"name\":\"").append(jsonEscape(agreementName)).append("\",");
-        sb.append("\"signatureType\":\"ESIGN\",");
-        sb.append("\"state\":\"IN_PROCESS\",");
-
-        if (message != null && !message.isEmpty()) {
-            sb.append("\"message\":\"").append(jsonEscape(message)).append("\",");
+            ParticipantSet set = new ParticipantSet();
+            set.memberInfos = Collections.singletonList(member);
+            set.order = 1;
+            set.role = s.getRole();
+            sets.add(set);
         }
+        return sets;
+    }
 
-        // Parallel signing: same order (1) for all participantSets.
-        sb.append("\"participantSetsInfo\":[");
+    private List<FormField> buildFormFields(List<Signer> signers) {
+        List<FormField> fields = new ArrayList<>();
         for (int i = 0; i < signers.size(); i++) {
             Signer s = signers.get(i);
-            if (i > 0) sb.append(',');
-            sb.append('{');
-            sb.append("\"memberInfos\":[{\"email\":\"").append(jsonEscape(s.getEmail())).append("\"");
-            if (s.getName() != null && !s.getName().isEmpty()) {
-                sb.append(",\"name\":\"").append(jsonEscape(s.getName())).append("\"");
-            }
-            sb.append("}],");
-            sb.append("\"order\":1,");
-            sb.append("\"role\":\"").append(jsonEscape(s.getRole())).append("\"");
-            sb.append('}');
-        }
-        sb.append("],");
 
-        // One signature field per signer.
-        sb.append("\"formFieldLayerTemplates\":[],");
-        sb.append("\"formFields\":[");
-        for (int i = 0; i < signers.size(); i++) {
-            Signer s = signers.get(i);
-            if (i > 0) sb.append(',');
-            int page = s.getSignaturePage() != null ? s.getSignaturePage() : DEFAULT_SIGNATURE_PAGE;
-            int x = s.getSignatureX() != null ? s.getSignatureX() : DEFAULT_SIGNATURE_X;
-            int y = s.getSignatureY() != null ? s.getSignatureY()
-                    : DEFAULT_SIGNATURE_Y_START + i * DEFAULT_SIGNATURE_Y_STEP;
-            sb.append('{');
-            sb.append("\"name\":\"sig_").append(i + 1).append("\",");
-            sb.append("\"contentType\":\"SIGNATURE\",");
-            sb.append("\"assignee\":{\"index\":").append(i + 1).append("},");
-            sb.append("\"locations\":[{");
-            sb.append("\"pageNumber\":").append(page).append(',');
-            sb.append("\"left\":").append(x).append(',');
-            sb.append("\"top\":").append(y).append(',');
-            sb.append("\"width\":").append(DEFAULT_SIGNATURE_WIDTH).append(',');
-            sb.append("\"height\":").append(DEFAULT_SIGNATURE_HEIGHT);
-            sb.append("}]}");
-        }
-        sb.append("]");
+            Assignee assignee = new Assignee();
+            assignee.index = i + 1;
 
-        sb.append('}');
-        return sb.toString();
+            Location loc = new Location();
+            loc.pageNumber = s.getSignaturePage() != null ? s.getSignaturePage() : DEFAULT_SIGNATURE_PAGE;
+            loc.left      = s.getSignatureX() != null ? s.getSignatureX() : DEFAULT_SIGNATURE_X;
+            loc.top       = s.getSignatureY() != null ? s.getSignatureY()
+                                : DEFAULT_SIGNATURE_Y_START + i * DEFAULT_SIGNATURE_Y_STEP;
+            loc.width  = DEFAULT_SIGNATURE_WIDTH;
+            loc.height = DEFAULT_SIGNATURE_HEIGHT;
+
+            FormField field = new FormField();
+            field.name        = "sig_" + (i + 1);
+            field.contentType = "SIGNATURE";
+            field.assignee    = assignee;
+            field.locations   = Collections.singletonList(loc);
+            fields.add(field);
+        }
+        return fields;
     }
 
     // ------------------------------------------------------------------
@@ -576,27 +574,53 @@ public class AdobeSignServiceImpl implements AdobeSignService {
         }
     }
 
-    static String jsonEscape(String s) {
-        if (s == null) return "";
-        StringBuilder sb = new StringBuilder(s.length() + 8);
-        for (int i = 0; i < s.length(); i++) {
-            char c = s.charAt(i);
-            switch (c) {
-                case '"':  sb.append("\\\""); break;
-                case '\\': sb.append("\\\\"); break;
-                case '\b': sb.append("\\b"); break;
-                case '\f': sb.append("\\f"); break;
-                case '\n': sb.append("\\n"); break;
-                case '\r': sb.append("\\r"); break;
-                case '\t': sb.append("\\t"); break;
-                default:
-                    if (c < 0x20) {
-                        sb.append(String.format("\\u%04x", (int) c));
-                    } else {
-                        sb.append(c);
-                    }
-            }
-        }
-        return sb.toString();
+    // ------------------------------------------------------------------
+    // Adobe Sign agreement payload DTOs
+    // ------------------------------------------------------------------
+
+    private static class AgreementPayload {
+        List<FileInfo>       fileInfos;
+        String               name;
+        String               signatureType;
+        String               state;
+        String               message;            // omitted by Gson when null
+        List<ParticipantSet> participantSetsInfo;
+        List<?>              formFieldLayerTemplates;
+        List<FormField>      formFields;
+    }
+
+    private static class FileInfo {
+        String transientDocumentId;
+        FileInfo(String id) { this.transientDocumentId = id; }
+    }
+
+    private static class ParticipantSet {
+        List<MemberInfo> memberInfos;
+        int              order;
+        String           role;
+    }
+
+    private static class MemberInfo {
+        String email;
+        String name;                             // omitted by Gson when null
+    }
+
+    private static class FormField {
+        String         name;
+        String         contentType;
+        Assignee       assignee;
+        List<Location> locations;
+    }
+
+    private static class Assignee {
+        int index;
+    }
+
+    private static class Location {
+        int pageNumber;
+        int left;
+        int top;
+        int width;
+        int height;
     }
 }

--- a/core/src/main/java/ca/yukon/aem/core/forms/services/impl/AdobeSignServiceImpl.java
+++ b/core/src/main/java/ca/yukon/aem/core/forms/services/impl/AdobeSignServiceImpl.java
@@ -1,0 +1,602 @@
+package ca.yukon.aem.core.forms.services.impl;
+
+import ca.yukon.aem.core.forms.model.Signer;
+import ca.yukon.aem.core.forms.services.AdobeSignService;
+import com.adobe.granite.crypto.CryptoException;
+import com.adobe.granite.crypto.CryptoSupport;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Implementation of {@link AdobeSignService} using Adobe Sign REST API v6.
+ *
+ * <p>Credentials are read from an AEM Adobe Sign Cloud Service config
+ * node (path supplied via the workflow step's {@code cloudConfigPath}
+ * argument). The config stores OAuth credentials, not an access token
+ * directly:</p>
+ *
+ * <ul>
+ *   <li>{@code client_id}</li>
+ *   <li>{@code client_secret} (encrypted)</li>
+ *   <li>{@code refresh_token} (encrypted)</li>
+ *   <li>{@code access_token_uri} (the {@code /oauth/v2/refresh} endpoint)</li>
+ *   <li>{@code api_access_point} (the regional REST API base URL)</li>
+ * </ul>
+ *
+ * <p>This class exchanges the refresh token for an access token on demand
+ * and caches it in memory (keyed by config path) until shortly before
+ * expiry. Concurrent refreshes for the same config are serialized.</p>
+ *
+ * <p>API documentation:
+ * https://secure.na1.adobesign.com/public/docs/restapi/v6</p>
+ */
+@Component(service = AdobeSignService.class, immediate = true)
+public class AdobeSignServiceImpl implements AdobeSignService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AdobeSignServiceImpl.class);
+
+    private static final String API_TRANSIENT_DOCS = "/api/rest/v6/transientDocuments";
+    private static final String API_AGREEMENTS = "/api/rest/v6/agreements";
+
+    private static final int CONNECT_TIMEOUT_MS = 10_000;
+    private static final int SOCKET_TIMEOUT_MS = 30_000;
+
+    /** Safety buffer subtracted from the OAuth expires_in to avoid races. */
+    private static final long TOKEN_EXPIRY_SKEW_MS = 60_000L;
+
+    // Defaults for signature field placement (PDF points).
+    static final int DEFAULT_SIGNATURE_PAGE = 1;
+    static final int DEFAULT_SIGNATURE_WIDTH = 180;
+    static final int DEFAULT_SIGNATURE_HEIGHT = 36;
+    static final int DEFAULT_SIGNATURE_X = 50;
+    static final int DEFAULT_SIGNATURE_Y_START = 100;
+    static final int DEFAULT_SIGNATURE_Y_STEP = DEFAULT_SIGNATURE_HEIGHT + 30;
+
+    // Property name aliases used across AEM versions on the Adobe Sign
+    // Cloud Service config node.
+    private static final String[] CLOUD_CLIENT_ID_KEYS    = {"client_id", "clientId"};
+    private static final String[] CLOUD_CLIENT_SECRET_KEYS = {"client_secret", "clientSecret"};
+    private static final String[] CLOUD_REFRESH_TOKEN_KEYS = {"refresh_token", "refreshToken"};
+    private static final String[] CLOUD_TOKEN_URI_KEYS     = {"access_token_uri", "accessTokenUri", "tokenEndpoint"};
+    private static final String[] CLOUD_BASEURL_KEYS       = {"api_access_point", "apiAccessPoint", "baseUrl", "baseURL"};
+    private static final String[] CLOUD_SENDER_KEYS        = {"senderEmail", "sender_email", "userEmail"};
+
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
+    private volatile CryptoSupport cryptoSupport;
+
+    /** Cached access tokens keyed by cloudConfigPath. */
+    private final ConcurrentHashMap<String, AccessToken> tokenCache = new ConcurrentHashMap<>();
+
+    @Activate
+    protected void activate() {
+        LOG.info("AdobeSignService activated. Credentials are resolved per-call from " +
+                "an AEM Adobe Sign Cloud Service config (cloudConfigPath workflow arg).");
+    }
+
+    @Override
+    public String uploadTransientDocument(String fileName, String mimeType,
+                                          InputStream fileContent,
+                                          ResourceResolver resolver,
+                                          String cloudConfigPath) throws IOException {
+        ApiContext ctx = buildContext(resolver, cloudConfigPath);
+        String boundary = "----YukonFormsBoundary" + UUID.randomUUID();
+        URL url = new URL(ctx.baseUrl + API_TRANSIENT_DOCS);
+
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        try {
+            conn.setRequestMethod("POST");
+            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+            conn.setReadTimeout(SOCKET_TIMEOUT_MS);
+            conn.setDoOutput(true);
+            conn.setRequestProperty("Authorization", "Bearer " + ctx.accessToken);
+            conn.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);
+
+            try (DataOutputStream out = new DataOutputStream(conn.getOutputStream())) {
+                String header = "--" + boundary + "\r\n" +
+                        "Content-Disposition: form-data; name=\"File\"; filename=\"" + fileName + "\"\r\n" +
+                        "Content-Type: " + mimeType + "\r\n\r\n";
+                out.write(header.getBytes(StandardCharsets.UTF_8));
+
+                byte[] buf = new byte[8192];
+                int read;
+                while ((read = fileContent.read(buf)) != -1) {
+                    out.write(buf, 0, read);
+                }
+                out.write(("\r\n--" + boundary + "--\r\n").getBytes(StandardCharsets.UTF_8));
+                out.flush();
+            }
+
+            String response = readResponse(conn, "uploadTransientDocument", cloudConfigPath);
+            return extractJsonStringField(response, "transientDocumentId");
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    @Override
+    public String createAgreement(String agreementName, String transientDocId,
+                                  List<Signer> signers, String message,
+                                  ResourceResolver resolver,
+                                  String cloudConfigPath) throws IOException {
+        if (signers == null || signers.isEmpty()) {
+            throw new IllegalArgumentException("At least one signer is required");
+        }
+        ApiContext ctx = buildContext(resolver, cloudConfigPath);
+        String body = buildAgreementPayload(agreementName, transientDocId, signers, message);
+        URL url = new URL(ctx.baseUrl + API_AGREEMENTS);
+
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        try {
+            conn.setRequestMethod("POST");
+            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+            conn.setReadTimeout(SOCKET_TIMEOUT_MS);
+            conn.setDoOutput(true);
+            conn.setRequestProperty("Authorization", "Bearer " + ctx.accessToken);
+            conn.setRequestProperty("Content-Type", "application/json");
+            conn.setRequestProperty("Accept", "application/json");
+
+            try (OutputStream out = conn.getOutputStream()) {
+                out.write(body.getBytes(StandardCharsets.UTF_8));
+            }
+
+            String response = readResponse(conn, "createAgreement", cloudConfigPath);
+            return extractJsonStringField(response, "id");
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    @Override
+    public String getAgreementStatus(String agreementId,
+                                     ResourceResolver resolver,
+                                     String cloudConfigPath) throws IOException {
+        ApiContext ctx = buildContext(resolver, cloudConfigPath);
+        URL url = new URL(ctx.baseUrl + API_AGREEMENTS + "/" + agreementId);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        try {
+            conn.setRequestMethod("GET");
+            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+            conn.setReadTimeout(SOCKET_TIMEOUT_MS);
+            conn.setRequestProperty("Authorization", "Bearer " + ctx.accessToken);
+            conn.setRequestProperty("Accept", "application/json");
+
+            String response = readResponse(conn, "getAgreementStatus", cloudConfigPath);
+            return extractJsonStringField(response, "status");
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // OAuth credentials + token cache
+    // ------------------------------------------------------------------
+
+    /**
+     * What we need on each API call: the base URL of the API + a valid
+     * bearer access token.
+     */
+    static class ApiContext {
+        final String baseUrl;
+        final String accessToken;
+        ApiContext(String baseUrl, String accessToken) {
+            this.baseUrl = baseUrl;
+            this.accessToken = accessToken;
+        }
+    }
+
+    /** OAuth refresh credentials read from the cloud config. */
+    static class OAuthConfig {
+        final String clientId;
+        final String clientSecret;
+        final String refreshToken;
+        final String tokenUri;
+        final String baseUrl;
+        OAuthConfig(String clientId, String clientSecret, String refreshToken,
+                    String tokenUri, String baseUrl) {
+            this.clientId = clientId;
+            this.clientSecret = clientSecret;
+            this.refreshToken = refreshToken;
+            this.tokenUri = tokenUri;
+            this.baseUrl = baseUrl;
+        }
+    }
+
+    /** Cached access token entry. */
+    static class AccessToken {
+        final String token;
+        final long expiresAtMillis;
+        AccessToken(String token, long expiresAtMillis) {
+            this.token = token;
+            this.expiresAtMillis = expiresAtMillis;
+        }
+        boolean isExpired() {
+            return System.currentTimeMillis() >= expiresAtMillis;
+        }
+    }
+
+    /**
+     * Resolve OAuth config from the cloud config node, get a valid access
+     * token (from cache or by refreshing), and return an {@link ApiContext}.
+     */
+    private ApiContext buildContext(ResourceResolver resolver, String cloudConfigPath) throws IOException {
+        if (cloudConfigPath == null || cloudConfigPath.isEmpty()) {
+            throw new IllegalStateException(
+                    "cloudConfigPath is required. Set it in the workflow step's PROCESS_ARGS, " +
+                            "pointing to /conf/.../settings/cloudconfigs/adobesign/<name>/jcr:content");
+        }
+        if (resolver == null) {
+            throw new IllegalStateException("ResourceResolver is required to read the cloud config");
+        }
+
+        OAuthConfig oauth = readOAuthConfig(resolver, cloudConfigPath);
+        if (oauth == null) {
+            throw new IllegalStateException(
+                    "Adobe Sign cloud config not readable at " + cloudConfigPath);
+        }
+
+        AccessToken cached = tokenCache.get(cloudConfigPath);
+        if (cached != null && !cached.isExpired()) {
+            return new ApiContext(oauth.baseUrl, cached.token);
+        }
+
+        // Single-flight refresh for this config path.
+        synchronized (cacheKeyLock(cloudConfigPath)) {
+            cached = tokenCache.get(cloudConfigPath);
+            if (cached != null && !cached.isExpired()) {
+                return new ApiContext(oauth.baseUrl, cached.token);
+            }
+            AccessToken fresh = refreshAccessToken(oauth);
+            tokenCache.put(cloudConfigPath, fresh);
+            return new ApiContext(oauth.baseUrl, fresh.token);
+        }
+    }
+
+    /** Use an interned String as a per-path lock to avoid global contention. */
+    private static Object cacheKeyLock(String path) {
+        return ("AdobeSignTokenLock::" + path).intern();
+    }
+
+    /**
+     * Resolve the resource holding the cloud config properties, accepting
+     * the path either with or without a trailing {@code /jcr:content}.
+     * The cloud config is a {@code cq:Page} so the actual properties live
+     * on its {@code jcr:content} child.
+     */
+    private Resource resolveCloudConfigResource(ResourceResolver resolver, String path) {
+        Resource res = resolver.getResource(path);
+        if (res != null) {
+            // If the supplied path is the page node, descend to jcr:content.
+            Resource content = res.getChild("jcr:content");
+            if (content != null) {
+                return content;
+            }
+            // The path may already be jcr:content (no child needed).
+            return res;
+        }
+        // Path didn't resolve directly; try appending jcr:content.
+        if (!path.endsWith("/jcr:content")) {
+            res = resolver.getResource(path + "/jcr:content");
+        }
+        return res;
+    }
+
+    private OAuthConfig readOAuthConfig(ResourceResolver resolver, String path) {
+        Resource res = resolveCloudConfigResource(resolver, path);
+        if (res == null) {
+            LOG.warn("Adobe Sign cloud config node not found at {} (also tried /jcr:content)", path);
+            return null;
+        }
+        ValueMap props = res.getValueMap();
+
+        String clientId = firstNonEmpty(props, CLOUD_CLIENT_ID_KEYS);
+        String clientSecret = firstNonEmpty(props, CLOUD_CLIENT_SECRET_KEYS);
+        String refreshToken = firstNonEmpty(props, CLOUD_REFRESH_TOKEN_KEYS);
+        String tokenUri = firstNonEmpty(props, CLOUD_TOKEN_URI_KEYS);
+        String baseUrl = firstNonEmpty(props, CLOUD_BASEURL_KEYS);
+
+        if (clientId == null || clientSecret == null || refreshToken == null
+                || tokenUri == null || baseUrl == null) {
+            LOG.warn("Cloud config at {} is missing OAuth properties. " +
+                            "Found clientId={}, clientSecret={}, refreshToken={}, tokenUri={}, baseUrl={}",
+                    path, clientId != null, clientSecret != null,
+                    refreshToken != null, tokenUri != null, baseUrl != null);
+            return null;
+        }
+        clientSecret = maybeDecrypt(clientSecret);
+        refreshToken = maybeDecrypt(refreshToken);
+        if (baseUrl.endsWith("/")) baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+
+        return new OAuthConfig(clientId, clientSecret, refreshToken, tokenUri, baseUrl);
+    }
+
+    /**
+     * Exchange the refresh token for an access token via the Adobe Sign
+     * OAuth refresh endpoint.
+     */
+    AccessToken refreshAccessToken(OAuthConfig oauth) throws IOException {
+        StringBuilder form = new StringBuilder()
+                .append("grant_type=").append(urlEncode("refresh_token"))
+                .append("&client_id=").append(urlEncode(oauth.clientId))
+                .append("&client_secret=").append(urlEncode(oauth.clientSecret))
+                .append("&refresh_token=").append(urlEncode(oauth.refreshToken));
+
+        URL url = new URL(oauth.tokenUri);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        try {
+            conn.setRequestMethod("POST");
+            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+            conn.setReadTimeout(SOCKET_TIMEOUT_MS);
+            conn.setDoOutput(true);
+            conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+            conn.setRequestProperty("Accept", "application/json");
+
+            try (OutputStream out = conn.getOutputStream()) {
+                out.write(form.toString().getBytes(StandardCharsets.UTF_8));
+            }
+
+            int code = conn.getResponseCode();
+            InputStream stream = (code >= 200 && code < 300) ? conn.getInputStream() : conn.getErrorStream();
+            String body = stream == null ? "" : readAll(stream);
+            if (code < 200 || code >= 300) {
+                LOG.error("Adobe Sign token refresh failed (HTTP {}): {}", code, body);
+                throw new IOException("Adobe Sign token refresh failed: HTTP " + code + " - " + body);
+            }
+
+            String accessToken = extractJsonStringField(body, "access_token");
+            Long expiresIn = extractJsonLongField(body, "expires_in"); // seconds
+            if (accessToken == null) {
+                throw new IOException("Adobe Sign refresh response did not contain access_token: " + body);
+            }
+            long ttlMs = (expiresIn != null ? expiresIn : 3600L) * 1000L;
+            long expiresAt = System.currentTimeMillis() + Math.max(0L, ttlMs - TOKEN_EXPIRY_SKEW_MS);
+            LOG.debug("Refreshed Adobe Sign access token (ttl={}s)", expiresIn);
+            return new AccessToken(accessToken, expiresAt);
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    private String maybeDecrypt(String value) {
+        if (value == null || value.isEmpty()) return value;
+        CryptoSupport cs = cryptoSupport;
+        if (cs == null) {
+            // No CryptoSupport at hand; assume plaintext. AEM stores
+            // encrypted values wrapped in braces, so log a hint.
+            if (value.startsWith("{") && value.endsWith("}")) {
+                LOG.warn("Value looks encrypted but CryptoSupport is unavailable. " +
+                        "The OAuth call will likely fail.");
+            }
+            return value;
+        }
+        try {
+            if (cs.isProtected(value)) {
+                return cs.unprotect(value);
+            }
+        } catch (CryptoException e) {
+            LOG.warn("Failed to decrypt protected value: {}", e.getMessage());
+        }
+        return value;
+    }
+
+    private static String firstNonEmpty(ValueMap props, String[] keys) {
+        for (String k : keys) {
+            String v = props.get(k, String.class);
+            if (v != null && !v.isEmpty()) return v;
+        }
+        return null;
+    }
+
+    private static String urlEncode(String s) {
+        try {
+            return URLEncoder.encode(s, "UTF-8");
+        } catch (Exception e) {
+            return s;
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Payload builder
+    // ------------------------------------------------------------------
+
+    String buildAgreementPayload(String agreementName, String transientDocId,
+                                 List<Signer> signers, String message) {
+        StringBuilder sb = new StringBuilder(1024);
+        sb.append('{');
+
+        sb.append("\"fileInfos\":[{\"transientDocumentId\":\"")
+                .append(jsonEscape(transientDocId)).append("\"}],");
+
+        sb.append("\"name\":\"").append(jsonEscape(agreementName)).append("\",");
+        sb.append("\"signatureType\":\"ESIGN\",");
+        sb.append("\"state\":\"IN_PROCESS\",");
+
+        if (message != null && !message.isEmpty()) {
+            sb.append("\"message\":\"").append(jsonEscape(message)).append("\",");
+        }
+
+        // Parallel signing: same order (1) for all participantSets.
+        sb.append("\"participantSetsInfo\":[");
+        for (int i = 0; i < signers.size(); i++) {
+            Signer s = signers.get(i);
+            if (i > 0) sb.append(',');
+            sb.append('{');
+            sb.append("\"memberInfos\":[{\"email\":\"").append(jsonEscape(s.getEmail())).append("\"");
+            if (s.getName() != null && !s.getName().isEmpty()) {
+                sb.append(",\"name\":\"").append(jsonEscape(s.getName())).append("\"");
+            }
+            sb.append("}],");
+            sb.append("\"order\":1,");
+            sb.append("\"role\":\"").append(jsonEscape(s.getRole())).append("\"");
+            sb.append('}');
+        }
+        sb.append("],");
+
+        // One signature field per signer.
+        sb.append("\"formFieldLayerTemplates\":[],");
+        sb.append("\"formFields\":[");
+        for (int i = 0; i < signers.size(); i++) {
+            Signer s = signers.get(i);
+            if (i > 0) sb.append(',');
+            int page = s.getSignaturePage() != null ? s.getSignaturePage() : DEFAULT_SIGNATURE_PAGE;
+            int x = s.getSignatureX() != null ? s.getSignatureX() : DEFAULT_SIGNATURE_X;
+            int y = s.getSignatureY() != null ? s.getSignatureY()
+                    : DEFAULT_SIGNATURE_Y_START + i * DEFAULT_SIGNATURE_Y_STEP;
+            sb.append('{');
+            sb.append("\"name\":\"sig_").append(i + 1).append("\",");
+            sb.append("\"contentType\":\"SIGNATURE\",");
+            sb.append("\"assignee\":{\"index\":").append(i + 1).append("},");
+            sb.append("\"locations\":[{");
+            sb.append("\"pageNumber\":").append(page).append(',');
+            sb.append("\"left\":").append(x).append(',');
+            sb.append("\"top\":").append(y).append(',');
+            sb.append("\"width\":").append(DEFAULT_SIGNATURE_WIDTH).append(',');
+            sb.append("\"height\":").append(DEFAULT_SIGNATURE_HEIGHT);
+            sb.append("}]}");
+        }
+        sb.append("]");
+
+        sb.append('}');
+        return sb.toString();
+    }
+
+    // ------------------------------------------------------------------
+    // HTTP / JSON helpers
+    // ------------------------------------------------------------------
+
+    /**
+     * Reads response body and throws IOException on non-2xx. If the failure
+     * is HTTP 401, also invalidates the cached access token so the next
+     * call refreshes.
+     */
+    private String readResponse(HttpURLConnection conn, String op, String cacheKey) throws IOException {
+        int code = conn.getResponseCode();
+        InputStream stream = (code >= 200 && code < 300) ? conn.getInputStream() : conn.getErrorStream();
+        String body = stream == null ? "" : readAll(stream);
+        if (code == 401 && cacheKey != null) {
+            tokenCache.remove(cacheKey);
+        }
+        if (code < 200 || code >= 300) {
+            LOG.error("AdobeSign {} failed (HTTP {}): {}", op, code, body);
+            throw new IOException("AdobeSign " + op + " failed: HTTP " + code + " - " + body);
+        }
+        LOG.debug("AdobeSign {} ok (HTTP {})", op, code);
+        return body;
+    }
+
+    private static String readAll(InputStream is) throws IOException {
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(is, StandardCharsets.UTF_8))) {
+            char[] buf = new char[4096];
+            int read;
+            StringBuilder out = new StringBuilder();
+            while ((read = reader.read(buf)) != -1) {
+                out.append(buf, 0, read);
+            }
+            return out.toString();
+        } finally {
+            try { is.close(); } catch (IOException ignored) { }
+        }
+    }
+
+    static String extractJsonStringField(String json, String fieldName) {
+        if (json == null) return null;
+        String needle = "\"" + fieldName + "\"";
+        int i = json.indexOf(needle);
+        if (i < 0) return null;
+        int colon = json.indexOf(':', i + needle.length());
+        if (colon < 0) return null;
+        int quote = json.indexOf('"', colon + 1);
+        if (quote < 0) return null;
+        StringBuilder out = new StringBuilder();
+        for (int p = quote + 1; p < json.length(); p++) {
+            char c = json.charAt(p);
+            if (c == '\\' && p + 1 < json.length()) {
+                char next = json.charAt(p + 1);
+                switch (next) {
+                    case '"':  out.append('"'); break;
+                    case '\\': out.append('\\'); break;
+                    case '/':  out.append('/'); break;
+                    case 'n':  out.append('\n'); break;
+                    case 't':  out.append('\t'); break;
+                    case 'r':  out.append('\r'); break;
+                    default:   out.append(next); break;
+                }
+                p++;
+            } else if (c == '"') {
+                return out.toString();
+            } else {
+                out.append(c);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Extract a top-level integer/long field value from a JSON response
+     * (e.g. "expires_in":3600).
+     */
+    static Long extractJsonLongField(String json, String fieldName) {
+        if (json == null) return null;
+        String needle = "\"" + fieldName + "\"";
+        int i = json.indexOf(needle);
+        if (i < 0) return null;
+        int colon = json.indexOf(':', i + needle.length());
+        if (colon < 0) return null;
+        int p = colon + 1;
+        while (p < json.length() && Character.isWhitespace(json.charAt(p))) p++;
+        int start = p;
+        while (p < json.length() && (Character.isDigit(json.charAt(p)) || json.charAt(p) == '-')) p++;
+        if (p == start) return null;
+        try {
+            return Long.parseLong(json.substring(start, p));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    static String jsonEscape(String s) {
+        if (s == null) return "";
+        StringBuilder sb = new StringBuilder(s.length() + 8);
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"':  sb.append("\\\""); break;
+                case '\\': sb.append("\\\\"); break;
+                case '\b': sb.append("\\b"); break;
+                case '\f': sb.append("\\f"); break;
+                case '\n': sb.append("\\n"); break;
+                case '\r': sb.append("\\r"); break;
+                case '\t': sb.append("\\t"); break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/core/src/main/java/ca/yukon/aem/core/forms/services/package-info.java
+++ b/core/src/main/java/ca/yukon/aem/core/forms/services/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+package ca.yukon.aem.core.forms.services;

--- a/core/src/main/java/ca/yukon/aem/core/forms/util/FormDataParser.java
+++ b/core/src/main/java/ca/yukon/aem/core/forms/util/FormDataParser.java
@@ -1,0 +1,146 @@
+package ca.yukon.aem.core.forms.util;
+
+import ca.yukon.aem.core.forms.model.Signer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Parses Adaptive Form submission data (XML) and extracts a list of
+ * {@link Signer}s from a repeatable panel.
+ *
+ * <p>The parser looks for repeating elements whose tag name matches
+ * {@code panelName} (e.g. {@code personsRepeat}). Inside each repeated
+ * element it reads child elements whose names are configured via the
+ * supplied {@link SignerFieldMapping}. Entries missing the email field
+ * are skipped.</p>
+ *
+ * <p>Designed to be tolerant: child names are case-insensitive, missing
+ * non-email children are simply omitted from the resulting Signer.</p>
+ */
+public final class FormDataParser {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FormDataParser.class);
+
+    private FormDataParser() {
+    }
+
+    /**
+     * Parse signers using the default field mapping (email/name/role/...).
+     */
+    public static List<Signer> parseSigners(String xml, String panelName) {
+        return parseSigners(xml, panelName, SignerFieldMapping.DEFAULT);
+    }
+
+    /**
+     * Parse signers using a custom {@link SignerFieldMapping}.
+     *
+     * @param xml       submitted form data XML content
+     * @param panelName the repeatable panel element name (e.g. "personsRepeat")
+     * @param mapping   names of child elements within each panel instance
+     * @return list of valid signers (those with non-empty email); empty on error
+     */
+    public static List<Signer> parseSigners(String xml, String panelName,
+                                            SignerFieldMapping mapping) {
+        if (xml == null || xml.isEmpty() || panelName == null || panelName.isEmpty()) {
+            return Collections.emptyList();
+        }
+        if (mapping == null) mapping = SignerFieldMapping.DEFAULT;
+        try (InputStream is = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))) {
+            return parseSigners(is, panelName, mapping);
+        } catch (Exception e) {
+            LOG.warn("Failed to parse form data XML for panel '{}': {}", panelName, e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
+    public static List<Signer> parseSigners(InputStream xmlStream, String panelName,
+                                            SignerFieldMapping mapping) {
+        if (mapping == null) mapping = SignerFieldMapping.DEFAULT;
+        List<Signer> signers = new ArrayList<>();
+        try {
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            dbf.setNamespaceAware(false);
+            // XXE protection.
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            DocumentBuilder db = dbf.newDocumentBuilder();
+            Document doc = db.parse(new InputSource(xmlStream));
+
+            XPath xpath = XPathFactory.newInstance().newXPath();
+            NodeList panels = (NodeList) xpath.evaluate(
+                    "//*[local-name()='" + panelName + "']",
+                    doc, XPathConstants.NODESET);
+
+            for (int i = 0; i < panels.getLength(); i++) {
+                Node panel = panels.item(i);
+                if (panel.getNodeType() == Node.ELEMENT_NODE) {
+                    Signer s = extractSigner((Element) panel, mapping);
+                    if (s != null && s.isValid()) {
+                        signers.add(s);
+                    } else if (s != null) {
+                        LOG.debug("Skipping signer with no '{}' value", mapping.getEmailField());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.warn("Error parsing form data for panel '{}': {}", panelName, e.toString());
+        }
+        return signers;
+    }
+
+    private static Signer extractSigner(Element panel, SignerFieldMapping mapping) {
+        String name = textOf(panel, mapping.getNameField());
+        String email = textOf(panel, mapping.getEmailField());
+        String role = textOf(panel, mapping.getRoleField());
+        Integer page = intOf(panel, mapping.getSignaturePageField());
+        Integer x = intOf(panel, mapping.getSignatureXField());
+        Integer y = intOf(panel, mapping.getSignatureYField());
+        return new Signer(name, email, role, page, x, y);
+    }
+
+    private static String textOf(Element parent, String childLocalName) {
+        NodeList all = parent.getElementsByTagName("*");
+        for (int i = 0; i < all.getLength(); i++) {
+            Node n = all.item(i);
+            if (n.getNodeType() == Node.ELEMENT_NODE &&
+                    childLocalName.equalsIgnoreCase(n.getLocalName() == null
+                            ? n.getNodeName() : n.getLocalName())) {
+                String text = n.getTextContent();
+                if (text != null) {
+                    String trimmed = text.trim();
+                    if (!trimmed.isEmpty()) return trimmed;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static Integer intOf(Element parent, String childLocalName) {
+        String s = textOf(parent, childLocalName);
+        if (s == null) return null;
+        try {
+            return Integer.parseInt(s);
+        } catch (NumberFormatException e) {
+            LOG.debug("Non-numeric value for {}: '{}'", childLocalName, s);
+            return null;
+        }
+    }
+}

--- a/core/src/main/java/ca/yukon/aem/core/forms/util/SignerFieldMapping.java
+++ b/core/src/main/java/ca/yukon/aem/core/forms/util/SignerFieldMapping.java
@@ -1,0 +1,62 @@
+package ca.yukon.aem.core.forms.util;
+
+/**
+ * Maps {@link ca.yukon.aem.core.forms.model.Signer} attributes to the
+ * actual child element names used inside a repeatable panel in submitted
+ * form data XML.
+ *
+ * <p>Forms are unlikely to all use the same field names — one form might
+ * call the email field {@code email}, another {@code petitionerEmail} or
+ * {@code signerEmail}. This mapping lets each workflow declare what names
+ * its form uses.</p>
+ *
+ * <p>Lookup is case-insensitive, so {@code email} matches {@code Email}
+ * or {@code EMAIL}.</p>
+ */
+public final class SignerFieldMapping {
+
+    /** Default mapping matching the conventional names. */
+    public static final SignerFieldMapping DEFAULT = new SignerFieldMapping(
+            "email", "name", "role",
+            "signaturePage", "signatureX", "signatureY");
+
+    private final String emailField;
+    private final String nameField;
+    private final String roleField;
+    private final String signaturePageField;
+    private final String signatureXField;
+    private final String signatureYField;
+
+    public SignerFieldMapping(String emailField, String nameField, String roleField,
+                              String signaturePageField,
+                              String signatureXField,
+                              String signatureYField) {
+        this.emailField = orDefault(emailField, "email");
+        this.nameField = orDefault(nameField, "name");
+        this.roleField = orDefault(roleField, "role");
+        this.signaturePageField = orDefault(signaturePageField, "signaturePage");
+        this.signatureXField = orDefault(signatureXField, "signatureX");
+        this.signatureYField = orDefault(signatureYField, "signatureY");
+    }
+
+    public String getEmailField() { return emailField; }
+    public String getNameField() { return nameField; }
+    public String getRoleField() { return roleField; }
+    public String getSignaturePageField() { return signaturePageField; }
+    public String getSignatureXField() { return signatureXField; }
+    public String getSignatureYField() { return signatureYField; }
+
+    private static String orDefault(String v, String fallback) {
+        return (v == null || v.trim().isEmpty()) ? fallback : v.trim();
+    }
+
+    @Override
+    public String toString() {
+        return "SignerFieldMapping{email=" + emailField +
+                ", name=" + nameField +
+                ", role=" + roleField +
+                ", signaturePage=" + signaturePageField +
+                ", signatureX=" + signatureXField +
+                ", signatureY=" + signatureYField + "}";
+    }
+}

--- a/core/src/main/java/ca/yukon/aem/core/forms/util/package-info.java
+++ b/core/src/main/java/ca/yukon/aem/core/forms/util/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+package ca.yukon.aem.core.forms.util;

--- a/core/src/main/java/ca/yukon/aem/core/forms/workflow/SendForSignatureProcess.java
+++ b/core/src/main/java/ca/yukon/aem/core/forms/workflow/SendForSignatureProcess.java
@@ -1,0 +1,279 @@
+package ca.yukon.aem.core.forms.workflow;
+
+import ca.yukon.aem.core.forms.model.Signer;
+import ca.yukon.aem.core.forms.services.AdobeSignService;
+import ca.yukon.aem.core.forms.util.FormDataParser;
+import ca.yukon.aem.core.forms.util.SignerFieldMapping;
+
+import com.adobe.granite.workflow.WorkflowException;
+import com.adobe.granite.workflow.WorkflowSession;
+import com.adobe.granite.workflow.exec.WorkItem;
+import com.adobe.granite.workflow.exec.WorkflowData;
+import com.adobe.granite.workflow.exec.WorkflowProcess;
+import com.adobe.granite.workflow.metadata.MetaDataMap;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+/**
+ * AEM Workflow Process Step: reads submitted form data from the workflow
+ * payload, extracts signers from a repeatable panel, and creates a single
+ * Adobe Sign agreement with one dynamic signer per repeated panel instance.
+ *
+ * <p>All signers receive the signing email in parallel; each is positioned
+ * as a separate {@code participantSet} with the same order value.</p>
+ *
+ * <h2>Inputs</h2>
+ * <ul>
+ *   <li>Workflow payload — a JCR path pointing to a form submission folder
+ *       (or a node) that contains the submitted data XML and (optionally) a
+ *       Document of Record PDF.</li>
+ *   <li>Process arguments (configured in the workflow step) — comma-separated
+ *       {@code key=value} pairs. Supported keys:
+ *       <ul>
+ *         <li>{@code cloudConfigPath} — JCR path to the AEM Adobe Sign Cloud
+ *             Service config to use for this workflow, e.g.
+ *             {@code /conf/yukon-forms/settings/cloudconfigs/adobesign/<name>/jcr:content}.
+ *             Different workflow models can target different configs.</li>
+ *         <li>{@code panelName} — repeatable panel element name. Default:
+ *             {@code personsRepeat}.</li>
+ *         <li>{@code dataResource} — relative path under the payload to the
+ *             submitted XML. Default: {@code data.xml}.</li>
+ *         <li>{@code pdfResource} — relative path under the payload to the
+ *             DoR PDF. Default: {@code dor.pdf}.</li>
+ *         <li>{@code message} — optional message included in signing emails.</li>
+ *         <li>{@code emailField} — child element holding signer email.
+ *             Default: {@code email}.</li>
+ *         <li>{@code nameField} — child element holding signer display name.
+ *             Default: {@code name}.</li>
+ *         <li>{@code roleField} — child element holding signer role
+ *             (SIGNER / APPROVER / etc). Default: {@code role}.</li>
+ *         <li>{@code signaturePageField} — child element with 1-based page
+ *             number for the signature field. Default: {@code signaturePage}.</li>
+ *         <li>{@code signatureXField} — child element with X coordinate
+ *             (PDF points). Default: {@code signatureX}.</li>
+ *         <li>{@code signatureYField} — child element with Y coordinate
+ *             (PDF points). Default: {@code signatureY}.</li>
+ *       </ul>
+ *   </li>
+ * </ul>
+ *
+ * <h2>Outputs</h2>
+ * <ul>
+ *   <li>Sets {@code adobeSignAgreementId} in workflow metadata.</li>
+ *   <li>Sets {@code adobeSignSignerCount} in workflow metadata.</li>
+ * </ul>
+ */
+@Component(
+        service = WorkflowProcess.class,
+        property = {
+                "process.label=Yukon - Send Form for Dynamic Signatures"
+        }
+)
+public class SendForSignatureProcess implements WorkflowProcess {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SendForSignatureProcess.class);
+
+    private static final String DEFAULT_PANEL_NAME = "personsRepeat";
+    private static final String DEFAULT_DATA_RESOURCE = "data.xml";
+    private static final String DEFAULT_PDF_RESOURCE = "dor.pdf";
+
+    static final String META_AGREEMENT_ID = "adobeSignAgreementId";
+    static final String META_SIGNER_COUNT = "adobeSignSignerCount";
+
+    @Reference
+    private AdobeSignService adobeSignService;
+
+    @Override
+    public void execute(WorkItem workItem, WorkflowSession workflowSession,
+                        MetaDataMap args) throws WorkflowException {
+
+        StepArgs stepArgs = StepArgs.parse(getProcessArg(args));
+        WorkflowData wfData = workItem.getWorkflowData();
+        String payloadPath = String.valueOf(wfData.getPayload());
+
+        LOG.info("SendForSignatureProcess starting. payload={} args={}", payloadPath, stepArgs);
+
+        ResourceResolver resolver = workflowSession.adaptTo(ResourceResolver.class);
+        if (resolver == null) {
+            throw new WorkflowException("Cannot adapt WorkflowSession to ResourceResolver");
+        }
+
+        Resource payload = resolver.getResource(payloadPath);
+        if (payload == null) {
+            throw new WorkflowException("Workflow payload not found at " + payloadPath);
+        }
+
+        try {
+            // 1. Read and parse submitted data
+            String xml = readResourceAsString(payload, stepArgs.dataResource);
+            if (xml == null) {
+                throw new WorkflowException(
+                        "Form data (" + stepArgs.dataResource + ") not found under " + payloadPath);
+            }
+            SignerFieldMapping mapping = stepArgs.toFieldMapping();
+            List<Signer> signers = FormDataParser.parseSigners(xml, stepArgs.panelName, mapping);
+            if (signers.isEmpty()) {
+                LOG.warn("No signers found in panel '{}' at {}. Skipping Adobe Sign step.",
+                        stepArgs.panelName, payloadPath);
+                wfData.getMetaDataMap().put(META_SIGNER_COUNT, 0);
+                return;
+            }
+            LOG.info("Found {} signer(s) in panel '{}'", signers.size(), stepArgs.panelName);
+
+            // 2. Upload PDF as transient document
+            byte[] pdfBytes = readResourceAsBytes(payload, stepArgs.pdfResource);
+            if (pdfBytes == null || pdfBytes.length == 0) {
+                throw new WorkflowException(
+                        "DoR PDF (" + stepArgs.pdfResource + ") not found under " + payloadPath);
+            }
+            String fileName = payload.getName() + ".pdf";
+            String transientId;
+            try (InputStream pdfStream = new ByteArrayInputStream(pdfBytes)) {
+                transientId = adobeSignService.uploadTransientDocument(
+                        fileName, "application/pdf", pdfStream,
+                        resolver, stepArgs.cloudConfigPath);
+            }
+            LOG.debug("Uploaded transient document: {}", transientId);
+
+            // 3. Create the agreement
+            String agreementName = buildAgreementName(payload);
+            String agreementId = adobeSignService.createAgreement(
+                    agreementName, transientId, signers, stepArgs.message,
+                    resolver, stepArgs.cloudConfigPath);
+            LOG.info("Created Adobe Sign agreement {} with {} signer(s)", agreementId, signers.size());
+
+            // 4. Store result in workflow metadata for downstream steps
+            wfData.getMetaDataMap().put(META_AGREEMENT_ID, agreementId);
+            wfData.getMetaDataMap().put(META_SIGNER_COUNT, signers.size());
+
+        } catch (IOException e) {
+            throw new WorkflowException("Adobe Sign call failed", e);
+        }
+    }
+
+    private static String getProcessArg(MetaDataMap args) {
+        return args == null ?  null  : args.get("PROCESS_ARGS", "string");
+    }
+
+    private String buildAgreementName(Resource payload) {
+        // Caller can override by setting a custom name in the OSGi config
+        // prefix; here we suffix the agreement name with the payload's
+        // last path segment for uniqueness/traceability.
+        return "Yukon Form - " + payload.getName();
+    }
+
+    private static String readResourceAsString(Resource parent, String relPath) {
+        byte[] bytes = readResourceAsBytes(parent, relPath);
+        return bytes == null ? null : new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    private static byte[] readResourceAsBytes(Resource parent, String relPath) {
+        Resource child = parent.getChild(relPath);
+        if (child == null) {
+            // Some submission storage places the file as a nt:file with
+            // jcr:content/jcr:data. Try the renditions-style path too.
+            child = parent.getChild(relPath + "/jcr:content");
+        }
+        if (child == null) {
+            return null;
+        }
+        InputStream is = child.adaptTo(InputStream.class);
+        if (is == null) {
+            // Try child's resource as nt:file
+            Resource jcrContent = child.getChild("jcr:content");
+            if (jcrContent != null) {
+                is = jcrContent.adaptTo(InputStream.class);
+            }
+        }
+        if (is == null) {
+            return null;
+        }
+        try (InputStream stream = is;
+             ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            byte[] buf = new byte[8192];
+            int read;
+            while ((read = stream.read(buf)) != -1) {
+                baos.write(buf, 0, read);
+            }
+            return baos.toByteArray();
+        } catch (IOException e) {
+            LOG.warn("Failed to read {}/{}: {}", parent.getPath(), relPath, e.getMessage());
+            return null;
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Process step arguments parsing
+    // ------------------------------------------------------------------
+
+    static class StepArgs {
+        String cloudConfigPath = null;
+        String panelName = DEFAULT_PANEL_NAME;
+        String dataResource = DEFAULT_DATA_RESOURCE;
+        String pdfResource = DEFAULT_PDF_RESOURCE;
+        String message = null;
+
+        // Per-form signer field name overrides; null = use the default
+        // ("email", "name", ...) from SignerFieldMapping.DEFAULT.
+        String emailField = null;
+        String nameField = null;
+        String roleField = null;
+        String signaturePageField = null;
+        String signatureXField = null;
+        String signatureYField = null;
+
+        static StepArgs parse(String raw) {
+            StepArgs out = new StepArgs();
+            if (raw == null || raw.trim().isEmpty()) return out;
+            for (String pair : raw.split("[,\\n]")) {
+                int eq = pair.indexOf('=');
+                if (eq < 0) continue;
+                String key = pair.substring(0, eq).trim();
+                String val = pair.substring(eq + 1).trim();
+                switch (key) {
+                    case "cloudConfigPath":    out.cloudConfigPath = val; break;
+                    case "panelName":          out.panelName = val; break;
+                    case "dataResource":       out.dataResource = val; break;
+                    case "pdfResource":        out.pdfResource = val; break;
+                    case "message":            out.message = val; break;
+                    case "emailField":         out.emailField = val; break;
+                    case "nameField":          out.nameField = val; break;
+                    case "roleField":          out.roleField = val; break;
+                    case "signaturePageField": out.signaturePageField = val; break;
+                    case "signatureXField":    out.signatureXField = val; break;
+                    case "signatureYField":    out.signatureYField = val; break;
+                    default:                   /* ignore unknown */    break;
+                }
+            }
+            return out;
+        }
+
+        SignerFieldMapping toFieldMapping() {
+            // Each argument is optional. The mapping constructor falls back
+            // to the conventional default when a value is null/empty.
+            return new SignerFieldMapping(
+                    emailField, nameField, roleField,
+                    signaturePageField, signatureXField, signatureYField);
+        }
+
+        @Override
+        public String toString() {
+            return "StepArgs{cloudConfigPath=" + (cloudConfigPath == null ? "<none>" : cloudConfigPath) +
+                    ", panelName=" + panelName +
+                    ", dataResource=" + dataResource +
+                    ", pdfResource=" + pdfResource +
+                    ", message=" + (message == null ? "<none>" : "set") +
+                    ", fieldMapping=" + toFieldMapping() + "}";
+        }
+    }
+}

--- a/core/src/main/java/ca/yukon/aem/core/forms/workflow/package-info.java
+++ b/core/src/main/java/ca/yukon/aem/core/forms/workflow/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+package ca.yukon.aem.core.forms.workflow;

--- a/core/src/test/java/ca/yukon/aem/core/forms/util/FormDataParserTest.java
+++ b/core/src/test/java/ca/yukon/aem/core/forms/util/FormDataParserTest.java
@@ -1,0 +1,311 @@
+package ca.yukon.aem.core.forms.util;
+
+import ca.yukon.aem.core.forms.model.Signer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FormDataParserTest {
+
+    @BeforeAll
+    static void forceJdkXmlParser() {
+        // The AEM SDK test classpath includes an old Xerces that does not implement
+        // setFeature(). Force JAXP to use the JDK's built-in parser instead.
+        System.setProperty("javax.xml.parsers.DocumentBuilderFactory",
+                "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl");
+        System.setProperty("javax.xml.xpath.XPathFactory:http://java.sun.com/jaxp/xpath/dom",
+                "com.sun.org.apache.xpath.internal.jaxp.XPathFactoryImpl");
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private static String wrap(String innerXml) {
+        return "<data>" + innerXml + "</data>";
+    }
+
+    private static String panel(String name, String... fields) {
+        StringBuilder sb = new StringBuilder("<").append(name).append(">");
+        for (String f : fields) sb.append(f);
+        return sb.append("</").append(name).append(">").toString();
+    }
+
+    private static String field(String name, String value) {
+        return "<" + name + ">" + value + "</" + name + ">";
+    }
+
+    // ------------------------------------------------------------------
+    // Happy path
+    // ------------------------------------------------------------------
+
+    @Test
+    void singleSigner_allFields_parsed() {
+        String xml = wrap(panel("signers",
+                field("email", "alice@example.com"),
+                field("name", "Alice"),
+                field("role", "SIGNER"),
+                field("signaturePage", "2"),
+                field("signatureX", "100"),
+                field("signatureY", "200")));
+
+        List<Signer> result = FormDataParser.parseSigners(xml, "signers");
+
+        assertEquals(1, result.size());
+        Signer s = result.get(0);
+        assertEquals("alice@example.com", s.getEmail());
+        assertEquals("Alice", s.getName());
+        assertEquals("SIGNER", s.getRole());
+        assertEquals(2, s.getSignaturePage());
+        assertEquals(100, s.getSignatureX());
+        assertEquals(200, s.getSignatureY());
+    }
+
+    @Test
+    void multipleSigners_allReturned() {
+        String xml = wrap(
+                panel("signers", field("email", "a@example.com"), field("name", "A")) +
+                panel("signers", field("email", "b@example.com"), field("name", "B")) +
+                panel("signers", field("email", "c@example.com"), field("name", "C")));
+
+        List<Signer> result = FormDataParser.parseSigners(xml, "signers");
+
+        assertEquals(3, result.size());
+        assertEquals("a@example.com", result.get(0).getEmail());
+        assertEquals("b@example.com", result.get(1).getEmail());
+        assertEquals("c@example.com", result.get(2).getEmail());
+    }
+
+    @Test
+    void optionalFieldsMissing_signerStillValid() {
+        String xml = wrap(panel("signers", field("email", "minimal@example.com")));
+
+        List<Signer> result = FormDataParser.parseSigners(xml, "signers");
+
+        assertEquals(1, result.size());
+        Signer s = result.get(0);
+        assertEquals("minimal@example.com", s.getEmail());
+        assertNull(s.getName());
+        assertEquals("SIGNER", s.getRole()); // Signer.getRole() defaults to SIGNER
+        assertNull(s.getSignaturePage());
+        assertNull(s.getSignatureX());
+        assertNull(s.getSignatureY());
+    }
+
+    // ------------------------------------------------------------------
+    // Filtering
+    // ------------------------------------------------------------------
+
+    @Test
+    void missingEmailField_entrySkipped() {
+        String xml = wrap(panel("signers", field("name", "NoEmail")));
+
+        List<Signer> result = FormDataParser.parseSigners(xml, "signers");
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void emptyEmailField_entrySkipped() {
+        String xml = wrap(panel("signers",
+                field("email", "   "),
+                field("name", "BlankEmail")));
+
+        List<Signer> result = FormDataParser.parseSigners(xml, "signers");
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void mixedValidAndInvalidEntries_onlyValidReturned() {
+        String xml = wrap(
+                panel("signers", field("email", "good@example.com")) +
+                panel("signers", field("name", "NoEmail")) +
+                panel("signers", field("email", "  ")));
+
+        List<Signer> result = FormDataParser.parseSigners(xml, "signers");
+
+        assertEquals(1, result.size());
+        assertEquals("good@example.com", result.get(0).getEmail());
+    }
+
+    // ------------------------------------------------------------------
+    // Null / empty guards
+    // ------------------------------------------------------------------
+
+    @Test
+    void nullXml_returnsEmpty() {
+        assertTrue(FormDataParser.parseSigners(null, "signers").isEmpty());
+    }
+
+    @Test
+    void emptyXml_returnsEmpty() {
+        assertTrue(FormDataParser.parseSigners("", "signers").isEmpty());
+    }
+
+    @Test
+    void nullPanelName_returnsEmpty() {
+        assertTrue(FormDataParser.parseSigners("<data/>", null).isEmpty());
+    }
+
+    @Test
+    void emptyPanelName_returnsEmpty() {
+        assertTrue(FormDataParser.parseSigners("<data/>", "").isEmpty());
+    }
+
+    @Test
+    void panelNameNotFound_returnsEmpty() {
+        String xml = wrap(panel("signers", field("email", "a@example.com")));
+
+        assertTrue(FormDataParser.parseSigners(xml, "unknownPanel").isEmpty());
+    }
+
+    // ------------------------------------------------------------------
+    // Error tolerance
+    // ------------------------------------------------------------------
+
+    @Test
+    void malformedXml_returnsEmpty() {
+        assertTrue(FormDataParser.parseSigners("<unclosed>", "signers").isEmpty());
+    }
+
+    @Test
+    void xxeDoctype_returnsEmpty() {
+        String xml = "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>" +
+                     "<data><signers><email>&xxe;</email></signers></data>";
+
+        List<Signer> result = FormDataParser.parseSigners(xml, "signers");
+
+        assertTrue(result.isEmpty());
+    }
+
+    // ------------------------------------------------------------------
+    // Case-insensitive field names
+    // ------------------------------------------------------------------
+
+    @Test
+    void fieldNamesCaseInsensitive_parsed() {
+        String xml = wrap(panel("signers",
+                field("EMAIL", "upper@example.com"),
+                field("Name", "Mixed")));
+
+        List<Signer> result = FormDataParser.parseSigners(xml, "signers");
+
+        assertEquals(1, result.size());
+        assertEquals("upper@example.com", result.get(0).getEmail());
+        assertEquals("Mixed", result.get(0).getName());
+    }
+
+    // ------------------------------------------------------------------
+    // Whitespace trimming
+    // ------------------------------------------------------------------
+
+    @Test
+    void fieldValuesWithWhitespace_trimmed() {
+        String xml = wrap(panel("signers",
+                field("email", "  spaces@example.com  "),
+                field("name", "\t Tabbed \n")));
+
+        List<Signer> result = FormDataParser.parseSigners(xml, "signers");
+
+        assertEquals(1, result.size());
+        assertEquals("spaces@example.com", result.get(0).getEmail());
+        assertEquals("Tabbed", result.get(0).getName());
+    }
+
+    // ------------------------------------------------------------------
+    // Signature coordinates
+    // ------------------------------------------------------------------
+
+    @Test
+    void invalidIntegerCoordinates_treatedAsNull() {
+        String xml = wrap(panel("signers",
+                field("email", "coord@example.com"),
+                field("signaturePage", "abc"),
+                field("signatureX", "1.5"),
+                field("signatureY", "")));
+
+        List<Signer> result = FormDataParser.parseSigners(xml, "signers");
+
+        assertEquals(1, result.size());
+        Signer s = result.get(0);
+        assertNull(s.getSignaturePage());
+        assertNull(s.getSignatureX());
+        assertNull(s.getSignatureY());
+    }
+
+    // ------------------------------------------------------------------
+    // Custom SignerFieldMapping
+    // ------------------------------------------------------------------
+
+    @Test
+    void customMapping_usesCustomFieldNames() {
+        SignerFieldMapping mapping = new SignerFieldMapping(
+                "petitionerEmail", "petitionerName", "petitionerRole",
+                "page", "xPos", "yPos");
+        String xml = wrap(panel("person",
+                field("petitionerEmail", "custom@example.com"),
+                field("petitionerName", "Custom"),
+                field("petitionerRole", "APPROVER"),
+                field("page", "3"),
+                field("xPos", "50"),
+                field("yPos", "150")));
+
+        List<Signer> result = FormDataParser.parseSigners(xml, "person", mapping);
+
+        assertEquals(1, result.size());
+        Signer s = result.get(0);
+        assertEquals("custom@example.com", s.getEmail());
+        assertEquals("Custom", s.getName());
+        assertEquals("APPROVER", s.getRole());
+        assertEquals(3, s.getSignaturePage());
+        assertEquals(50, s.getSignatureX());
+        assertEquals(150, s.getSignatureY());
+    }
+
+    @Test
+    void nullMapping_fallsBackToDefault() {
+        String xml = wrap(panel("signers", field("email", "default@example.com")));
+
+        List<Signer> result = FormDataParser.parseSigners(xml, "signers", null);
+
+        assertEquals(1, result.size());
+        assertEquals("default@example.com", result.get(0).getEmail());
+    }
+
+    // ------------------------------------------------------------------
+    // InputStream overload
+    // ------------------------------------------------------------------
+
+    @Test
+    void inputStreamOverload_parsed() {
+        String xml = wrap(panel("signers", field("email", "stream@example.com")));
+        ByteArrayInputStream stream = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+
+        List<Signer> result = FormDataParser.parseSigners(stream, "signers", SignerFieldMapping.DEFAULT);
+
+        assertEquals(1, result.size());
+        assertEquals("stream@example.com", result.get(0).getEmail());
+    }
+
+    // ------------------------------------------------------------------
+    // Nested structure
+    // ------------------------------------------------------------------
+
+    @Test
+    void panelNestedInsideOtherElement_stillFound() {
+        String xml = wrap("<section><group>" +
+                panel("signers", field("email", "nested@example.com")) +
+                "</group></section>");
+
+        List<Signer> result = FormDataParser.parseSigners(xml, "signers");
+
+        assertEquals(1, result.size());
+        assertEquals("nested@example.com", result.get(0).getEmail());
+    }
+}

--- a/ui.content/src/main/content/META-INF/vault/filter.xml
+++ b/ui.content/src/main/content/META-INF/vault/filter.xml
@@ -23,4 +23,6 @@
     <filter root="/content/forms/af/yukon-forms/" mode="merge"/>
 	<filter root="/etc/clientlibs/fr-ca"/>
 	<filter root="/etc/languages"/>
+    <filter root="/var/workflow/models/yukon-petition-dynamic-signatures" mode="merge"/>
+    <filter root="/conf/global/settings/workflow/models/yukon-petition-dynamic-signatures" mode="merge"/>
 </workspaceFilter>

--- a/ui.content/src/main/content/jcr_root/conf/global/settings/workflow/models/yukon-petition-dynamic-signatures/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/global/settings/workflow/models/yukon-petition-dynamic-signatures/.content.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:designPath="/libs/settings/wcm/designs/default"
+        cq:lastModified="{Date}2026-05-15T13:56:51.884-07:00"
+        cq:lastModifiedBy="admin"
+        cq:template="/libs/cq/workflow/templates/model"
+        jcr:primaryType="cq:PageContent"
+        jcr:title="Yukon Petition - Dynamic Signatures"
+        sling:resourceType="cq/workflow/components/pages/model"
+        lastSynced="{Date}2026-05-15T13:56:53.891-07:00">
+        <flow
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="foundation/components/parsys">
+            <process
+                jcr:created="{Date}2026-05-14T20:46:33.625-07:00"
+                jcr:createdBy="admin"
+                jcr:lastModified="{Date}2026-05-15T13:56:51.879-07:00"
+                jcr:lastModifiedBy="admin"
+                jcr:primaryType="nt:unstructured"
+                jcr:title="Yukon Petition - Dynamic Signatures"
+                sling:resourceType="cq/workflow/components/model/process">
+                <metaData
+                    jcr:primaryType="nt:unstructured"
+                    PROCESS="ca.yukon.aem.core.forms.workflow.SendForSignatureProcess"
+                    PROCESS_ARGS="cloudConfigPath=/conf/yukon-forms/settings/cloudconfigs/echosign/eu-adobe-sign-integration&#xd;&#xa;panelName=petitionersRepeat&#xd;&#xa;dataResource=data.xml&#xd;&#xa;pdfResource=dor.pdf&#xd;&#xa;emailField=email&#xd;&#xa;nameField=name"
+                    PROCESS_AUTO_ADVANCE="true"/>
+            </process>
+        </flow>
+    </jcr:content>
+</jcr:root>

--- a/ui.content/src/main/content/jcr_root/var/workflow/models/yukon-petition-dynamic-signatures.xml
+++ b/ui.content/src/main/content/jcr_root/var/workflow/models/yukon-petition-dynamic-signatures.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    jcr:isCheckedOut="{Boolean}false"
+    jcr:primaryType="cq:WorkflowModel"
+    jcr:uuid="5984ce82-10a3-437c-8f1a-8416a0562c55"
+    sling:resourceType="cq/workflow/components/model"
+    description="No Description"
+    title="Yukon Petition - Dynamic Signatures">
+    <metaData
+        cq:generatingPage="/conf/global/settings/workflow/models/yukon-petition-dynamic-signatures/jcr:content"
+        cq:lastModified="{Long}1778878613893"
+        cq:lastModifiedBy="admin"
+        jcr:primaryType="nt:unstructured"
+        lastSynced="{Date}2026-05-15T13:56:53.891-07:00"/>
+    <nodes jcr:primaryType="nt:unstructured">
+        <node0
+            jcr:primaryType="cq:WorkflowNode"
+            title="Start"
+            type="START">
+            <metaData jcr:primaryType="nt:unstructured"/>
+        </node0>
+        <node1
+            jcr:primaryType="cq:WorkflowNode"
+            title="Yukon Petition - Dynamic Signatures"
+            type="PROCESS">
+            <metaData
+                jcr:primaryType="nt:unstructured"
+                PROCESS="ca.yukon.aem.core.forms.workflow.SendForSignatureProcess"
+                PROCESS_ARGS="cloudConfigPath=/conf/yukon-forms/settings/cloudconfigs/echosign/eu-adobe-sign-integration&#xd;&#xa;panelName=petitionersRepeat&#xd;&#xa;dataResource=data.xml&#xd;&#xa;pdfResource=dor.pdf&#xd;&#xa;emailField=email&#xd;&#xa;nameField=name"
+                PROCESS_AUTO_ADVANCE="true"/>
+        </node1>
+        <node2
+            jcr:primaryType="cq:WorkflowNode"
+            title="End"
+            type="END">
+            <metaData jcr:primaryType="nt:unstructured"/>
+        </node2>
+    </nodes>
+    <transitions jcr:primaryType="nt:unstructured">
+        <node0_x0023_node1
+            jcr:primaryType="cq:WorkflowTransition"
+            from="node0"
+            rule="\0"
+            to="node1">
+            <metaData jcr:primaryType="nt:unstructured"/>
+        </node0_x0023_node1>
+        <node1_x0023_node2
+            jcr:primaryType="cq:WorkflowTransition"
+            from="node1"
+            to="node2">
+            <metaData jcr:primaryType="nt:unstructured"/>
+        </node1_x0023_node2>
+    </transitions>
+</jcr:root>


### PR DESCRIPTION
The workflow name is "Yukon Petition - Dynamic Signatures". It has following configurations:

   - `cloudConfigPath` — JCR path to the AEM Adobe Sign Cloud Service config to use for this workflow
   - `panelName` — repeatable panel element name (default `personsRepeat`)
   - `dataResource` — relative path under the payload to the submitted XML (default `data.xml`)
   - `pdfResource` — relative path under the payload to the DoR PDF (default `dor.pdf`)
   - `message` — optional message included in signing emails
   - `emailField` — child element holding signer email (default `email`)
   - `nameField` — child element holding display name (default `name`)

The form settings are below:

Submission: 
<img width="646" height="589" alt="Screenshot 2026-05-15 at 3 57 43 PM" src="https://github.com/user-attachments/assets/af2a62f9-42bc-4433-bfab-c453033bf113" />

Electronic Signature:
Uncheck "Enable Adobe Sign"