### PR TITLE
eServices - Fix accordion tabs interoperability with keyboard (production)

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/less/yukon-experience-fragments.less
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/less/yukon-experience-fragments.less
@@ -1,3 +1,8 @@
 header.yukon-header {
   border-bottom: 4px solid #ffcd57;
 }
+
+footer.yukon-footer {
+ border-top: 4px solid #ffcd57;
+}
+

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/panelcontainer/clientlibs/js/panel.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/panelcontainer/clientlibs/js/panel.js
@@ -25,6 +25,80 @@ function setAccordion(accordionEl, expand) {
   });
 }
 
+function _removeAccordionElement(e) {
+  var tab = e.target.closest('.accordion-navigators > div');
+  if (!tab) return;
+  
+  // Check for a control button, in which case, use that instead of the default remove button
+  var removeControl = tab.querySelector('.removeAccordionControl button');
+  if (!removeControl) {
+    return;
+  }
+  e.stopPropagation();
+  e.preventDefault();
+  removeControl.click();
+}
+
+function _openCloseAccordionElement(e) {
+
+  var toggle = e.target.closest('[data-guide-toggle="accordion-tab"]');
+  if (!toggle) return;
+  
+  var panel = toggle.closest('[data-guide-parent-id]');
+  if (!panel) return;
+
+  var btn = panel.querySelector('[aria-expanded]');
+  var content = panel.querySelector('.afAccordionPanel');
+  var isExpanded = btn && btn.getAttribute('aria-expanded') === 'true';
+
+  if (isExpanded) {
+    panel.classList.remove('active');
+    if (btn) {
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-pressed', 'false');
+    }
+    if (content) content.style.display = 'none';
+  } else {
+    panel.classList.add('active');
+    if (btn) {
+      btn.setAttribute('aria-expanded', 'true');
+      btn.setAttribute('aria-pressed', 'true');
+    }
+    if (content) content.style.display = '';
+  }
+
+}
+
+function _handleAccordionInteraction(e) {
+  var toggle = e.target.closest('[data-guide-toggle="accordion-tab"]');
+  if (!toggle) return;
+
+  var tab = e.target.closest('.accordion-navigators > div');
+  if (!tab) return;
+  // Find the .accordion-navigators this toggle belongs to
+  var accordionNav = tab.closest('.accordion-navigators');
+  if (!accordionNav) return;
+
+  // Walk up to the outermost guide-item wrapper that contains this accordion
+  var accordionWrapper = accordionNav.closest('[data-guide-parent-id]');
+  if (!accordionWrapper) return;
+
+  // Check if a sibling expand/collapse button exists
+  var hasManagedButton = accordionWrapper.parentElement ? accordionWrapper.parentElement.querySelector(
+    '.expandAllPanelsButton, ' +
+    '.collapseAllPanelsButton'
+  ) : null;
+
+  // If no expand/collapse button nearby, var AEM handle it normally
+  if (!hasManagedButton) return;
+
+  // Otherwise, stop AEM's listener from firing
+  e.stopPropagation();
+  e.preventDefault();
+  
+  _openCloseAccordionElement(e);
+}
+
 document.addEventListener('click', function(e) {
   var expandBtn = e.target.closest('.expandAllPanelsButton');
   var collapseBtn = e.target.closest('.collapseAllPanelsButton');
@@ -53,66 +127,24 @@ document.addEventListener('click', function(e) {
 // Replace AEM's built-in panel header functionality to work with our expand/collapse all
 document.addEventListener('click', function(e) {
 
-  var toggle = e.target.closest('[data-guide-toggle="accordion-tab"]');
-  if (!toggle) return;
-
-  var tab = e.target.closest('.accordion-navigators > div');
-  if (!tab) return;
-
   // Allow the remove button to work normally
   if (e.target.closest('[data-guide-addremove="remove"]')) {
-    // Check for a control button, in which case, use that instead of the default remove button
-    var removeControl = tab.querySelector('.removeAccordionControl button');
-    if (!removeControl) {
-      return;
-    }
-    e.stopPropagation();
-    e.preventDefault();
-    removeControl.click();
+    _removeAccordionElement(e);
     return;
   }
 
-  // Find the .accordion-navigators this toggle belongs to
-  var accordionNav = tab.closest('.accordion-navigators');
-  if (!accordionNav) return;
+  _handleAccordionInteraction(e);
+}, true);
 
-  // Walk up to the outermost guide-item wrapper that contains this accordion
-  var accordionWrapper = accordionNav.closest('[data-guide-parent-id]');
-  if (!accordionWrapper) return;
-
-  // Check if a sibling expand/collapse button exists
-  var hasManagedButton = accordionWrapper.parentElement ? accordionWrapper.parentElement.querySelector(
-    '.expandAllPanelsButton, ' +
-    '.collapseAllPanelsButton'
-  ) : null;
-
-  // If no expand/collapse button nearby, var AEM handle it normally
-  if (!hasManagedButton) return;
-
-  // Otherwise, stop AEM's listener from firing
-  e.stopPropagation();
-  e.preventDefault();
-
-  var panel = toggle.closest('[data-guide-parent-id]');
-  if (!panel) return;
-
-  var btn = panel.querySelector('[aria-expanded]');
-  var content = panel.querySelector('.afAccordionPanel');
-  var isExpanded = btn && btn.getAttribute('aria-expanded') === 'true';
-
-  if (isExpanded) {
-    panel.classList.remove('active');
-    if (btn) {
-      btn.setAttribute('aria-expanded', 'false');
-      btn.setAttribute('aria-pressed', 'false');
+document.addEventListener('keydown', function(e) {
+  if (e.key === "Enter") {
+    // Allow the remove button to work normally
+    if (e.target.closest('[data-guide-addremove="remove"]')) {
+      _removeAccordionElement(e);
+      return;
     }
-    if (content) content.style.display = 'none';
-  } else {
-    panel.classList.add('active');
-    if (btn) {
-      btn.setAttribute('aria-expanded', 'true');
-      btn.setAttribute('aria-pressed', 'true');
-    }
-    if (content) content.style.display = '';
+  }
+  if (e.code === "Space") {
+    _handleAccordionInteraction(e);
   }
 }, true);


### PR DESCRIPTION
The custom open, close, and remove mechanisms we implemented previously were only called upon clicks. This PR adds 'keydown' events so that it also works with the keyboard.