### PR TITLE
Canada post address

### DIFF
--- a/core/src/main/java/ca/yukon/aem/core/models/AddressModel.java
+++ b/core/src/main/java/ca/yukon/aem/core/models/AddressModel.java
@@ -2,6 +2,7 @@ package ca.yukon.aem.core.models;
 
 import ca.yukon.aem.core.forms.services.impl.CanadaPostApiService;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Default;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
@@ -28,6 +29,21 @@ public class AddressModel {
         }
     }
 
+    @ValueMapValue @Default(values = "addressLine1")
+    private String fieldLine1;
+
+    @ValueMapValue @Default(values = "addressLine2")
+    private String fieldLine2;
+
+    @ValueMapValue @Default(values = "city")
+    private String fieldCity;
+
+    @ValueMapValue @Default(values = "province")
+    private String fieldProvince;
+
+    @ValueMapValue @Default(values = "postalCode")
+    private String fieldPostalCode;
+
     public String getHost() {
         return this.host;
     }
@@ -39,4 +55,9 @@ public class AddressModel {
     public int getLimit() {
         return this.limit;
     }
+    public String getFieldLine1()  { return fieldLine1; }
+    public String getFieldLine2()  { return fieldLine2; }
+    public String getFieldCity()   { return fieldCity; }
+    public String getFieldProvince()   { return fieldProvince; }
+    public String getFieldPostalCode() { return fieldPostalCode; }
 }

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/address/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/address/.content.xml
@@ -2,6 +2,6 @@
 <jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
     jcr:description="Yukon Form Address component"
     jcr:primaryType="cq:Component"
-    jcr:title="Canada API Address component"
+    jcr:title="Canada Post API Address"
     sling:resourceSuperType="fd/af/components/guidetextbox"
     componentGroup="Adaptive Form"/>

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/address/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/address/.content.xml
@@ -2,6 +2,6 @@
 <jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
     jcr:description="Yukon Form Address component"
     jcr:primaryType="cq:Component"
-    jcr:title="Canada Post API Address"
+    jcr:title="Canada API Address component"
     sling:resourceSuperType="fd/af/components/guidetextbox"
     componentGroup="Adaptive Form"/>

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/address/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/address/_cq_dialog/.content.xml
@@ -28,15 +28,50 @@
                         jcr:title="Canada Post"
                         sling:resourceType="granite/ui/components/coral/foundation/container">
                         <items jcr:primaryType="nt:unstructured">
-                            <value
+                            <searchLimit
                                 granite:class="plainTextValue"
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
                                 defaultValue="7"
-                                fieldLabel="Search Limits"
+                                fieldLabel="Search Limit"
                                 max="10"
                                 min="0"
                                 name="./limit"/>
+                            <fieldLine1
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                fieldLabel="Field Name Of Address Line 1"
+                                fieldDescription="CSS class of the panel containing the address line 1 input."
+                                defaultValue="addressLine1"
+                                name="./fieldLine1"/>
+                            <fieldLine2
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                fieldLabel="Field Name Of Address Line 2"
+                                fieldDescription="CSS class of the panel containing the address line 2 input."
+                                defaultValue="addressLine2"
+                                name="./fieldLine2"/>
+                            <fieldCity
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                fieldLabel="Field Name Of City"
+                                fieldDescription="CSS class of the panel containing the city input."
+                                defaultValue="city"
+                                name="./fieldCity"/>
+                            <fieldProvince
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                fieldLabel="Field Name Of Province"
+                                fieldDescription="CSS class of the panel containing the province input."
+                                defaultValue="province"
+                                name="./fieldProvince"/>
+                            <fieldPostalCode
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                fieldLabel="Field Name Of Postal Code"
+                                fieldDescription="CSS class of the panel containing the postal code input."
+                                defaultValue="postalCode"
+                                name="./fieldPostalCode"/>
                         </items>
                     </address>
                 </items>

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/address/_cq_template/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/address/_cq_template/.content.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
     jcr:primaryType="nt:unstructured"
-    jcr:title="Canada Post API"
+    jcr:title="Address Line 1"
     guideNodeClass="guideTextBox"/>

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/address/clientlibs/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/address/clientlibs/.content.xml
@@ -2,4 +2,5 @@
 <jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
     jcr:primaryType="cq:ClientLibraryFolder"
     allowProxy="{Boolean}true"
-    categories="[yukon-forms.components]"/>
+    categories="[yukon-forms.components]"
+    dependencies="[yukon-forms.typeahead]"/>

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/address/clientlibs/js/address.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/address/clientlibs/js/address.js
@@ -25,11 +25,9 @@
             this.host = this.element.data("host");
             this.key = this.element.data("key");
             this.fixedLimit = this.element.data("limit") || 7;
-            this.limit = this.fixedLimit;
             this.language = this.element.data("language") || "en";
             this.isFrench = this.language.includes("fr");
             this.language = this.isFrench ? "fr" : "en";
-            this.usingRefinedSuggestions = false;
             this.fieldLine1    = this.element.data('field-line1')    || 'addressLine1';
             this.fieldLine2    = this.element.data('field-line2')    || 'addressLine2';
             this.fieldCity     = this.element.data('field-city')     || 'city';
@@ -40,17 +38,8 @@
                 console.error("Invalid Canada Post HOST...")
                 return;
             }
-            // setting initial typeahead objects
-            this.addressEngine = new Bloodhound({
-                remote: {
-                    url: this.getUrl(),
-                    wildcard: '%QUERY'
-                },
-                datumTokenizer: Bloodhound.tokenizers.whitespace,
-                queryTokenizer: Bloodhound.tokenizers.whitespace
-            });
             this.widget = $(input);
-            this.initTypeahead(this.addressEngine);
+            this.initTypeahead(this._buildSource());
             this.addEventListeners();
         }
 
@@ -88,7 +77,7 @@
                 {
                     name: 'address-suggestions',
                     display: 'Text',
-                    limit: this.limit,
+                    limit: 100,
                     source: sourceEngine,
                     templates: {
                         suggestion: function(data) {
@@ -116,29 +105,7 @@
                     return;
                 }
 
-                // when user selects on dropdown with multiple address
-                if (suggestion.Next === "Find") {
-                    let url = self.getUrl({Id: suggestion.Id, text: suggestion.Text, limit: 200})
-                    $.ajax({
-                        url: url,
-                        dataType: 'json',
-                        success: function(newResponse) {
-                            const newSuggestions = newResponse.Items || [];
-                            self.limit = newSuggestions.length;
-                            self.initTypeahead(function(query, syncResults, asyncResults) {
-                                syncResults(newSuggestions);
-                            });
-                            self.widget.typeahead('val', suggestion.Text);
-                            self.widget.focus();
-                            self.usingRefinedSuggestions = true;
-                        },
-                        error: function() {
-                            console.log('Unable to find following address...');
-                        }
-                    });
-                } else {
-                    // for single address selection
-                    $.ajax({
+                $.ajax({
                         url: self.host + '/addresscomplete/interactive/retrieve/v2.11/json3.ws',
                         data: {
                             Key: self.key,
@@ -156,7 +123,6 @@
                             if (!address && items.length > 0) {
                                 address = items[0];
                             }
-                            self.limit = self.fixedLimit;
                             self.container.find('.' + CSS.escape(self.fieldLine1)).find('input').val(address.Line1).blur();
                             self.container.find('.' + CSS.escape(self.fieldLine2)).find('input').val(address.Line2).blur();
                             self.container.find('.' + CSS.escape(self.fieldCity)).find('input').val(address.City).blur();
@@ -169,17 +135,47 @@
                             console.log('Unable to find selected address...');
                         }
                     });
-                }
             });
+        }
 
-            // resets typeahead source after drilling into a multi-address result
-            this.widget.on('blur', function() {
-                if (self.usingRefinedSuggestions) {
-                    self.usingRefinedSuggestions = false;
-                    self.limit = self.fixedLimit;
-                    self.initTypeahead(self.addressEngine);
-                }
-            });
+        _buildSource() {
+            const self = this;
+            return function(query, syncResults, asyncResults) {
+                $.ajax({
+                    url: self.getUrl({ text: query, limit: self.fixedLimit }),
+                    dataType: 'json',
+                    success: function(response) {
+                        const items = response.Items || [];
+                        const findItems = items.filter(function(i) { return i.Next === 'Find'; });
+                        const directItems = items.filter(function(i) { return i.Next !== 'Find'; });
+
+                        if (findItems.length === 0) {
+                            asyncResults(directItems);
+                            return;
+                        }
+
+                        let pending = findItems.length;
+                        let allItems = directItems.slice();
+
+                        findItems.forEach(function(item) {
+                            $.ajax({
+                                url: self.getUrl({ Id: item.Id, text: item.Text, limit: 200 }),
+                                dataType: 'json',
+                                success: function(sub) {
+                                    allItems = allItems.concat(sub.Items || []);
+                                    if (--pending === 0) asyncResults(allItems);
+                                },
+                                error: function() {
+                                    if (--pending === 0) asyncResults(allItems);
+                                }
+                            });
+                        });
+                    },
+                    error: function() {
+                        asyncResults([]);
+                    }
+                });
+            };
         }
     }
 

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/address/clientlibs/js/address.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/address/clientlibs/js/address.js
@@ -157,11 +157,11 @@
                                 address = items[0];
                             }
                             self.limit = self.fixedLimit;
-                            self.container.find('.' + self.fieldLine1).find('input').val(address.Line1).blur();
-                            self.container.find('.' + self.fieldLine2).find('input').val(address.Line2).blur();
-                            self.container.find('.' + self.fieldCity).find('input').val(address.City).blur();
-                            self.container.find('.' + self.fieldProvince).find('input').val(address.ProvinceCode).blur();
-                            self.container.find('.' + self.fieldPostalCode).find('input').val(address.PostalCode).blur();
+                            self.container.find('.' + CSS.escape(self.fieldLine1)).find('input').val(address.Line1).blur();
+                            self.container.find('.' + CSS.escape(self.fieldLine2)).find('input').val(address.Line2).blur();
+                            self.container.find('.' + CSS.escape(self.fieldCity)).find('input').val(address.City).blur();
+                            self.container.find('.' + CSS.escape(self.fieldProvince)).find('input').val(address.ProvinceCode).blur();
+                            self.container.find('.' + CSS.escape(self.fieldPostalCode)).find('input').val(address.PostalCode).blur();
                             self.widget.val(address.Line1);
                             self.widget.blur();
                         },

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/address/clientlibs/js/address.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/address/clientlibs/js/address.js
@@ -1,23 +1,40 @@
 (function() {
     "use strict";
-    class AddressInput {
-        static bemBlock = 'cmp-adaptiveform-addressinput';
-        static selectors = {
-            widget: `.${AddressInput.bemBlock}__widget`
-        };
 
+    const INIT_KEY = 'addressInputInitialized';
+
+    function initAll(root) {
+        (root || document).querySelectorAll(
+            '[data-cmp-is="adaptiveFormAddressInput"] .cmp-adaptiveform-addressinput__widget'
+        ).forEach(function(input) {
+            new AddressInput(input);
+        });
+    }
+
+    class AddressInput {
         // initializing input field with canada post api
-        constructor(params) {
-            this.element = params.element;
-            this.container = params.formContainer;
-            this.host = $(this.element).data("host");
-            this.key = $(this.element).data("key");
-            this.fixedLimit = $(this.element).data("limit") || 7;
+        constructor(input) {
+            if ($(input).data(INIT_KEY)) return;
+            $(input).data(INIT_KEY, true);
+
+            this.element = $(input).closest('.address_container');
+            this.container = this.element.closest('.panel');
+            if (this.container.length === 0) {
+                this.container = this.element.closest('.rootPanel');
+            }
+            this.host = this.element.data("host");
+            this.key = this.element.data("key");
+            this.fixedLimit = this.element.data("limit") || 7;
             this.limit = this.fixedLimit;
-            this.language = $(this.element).data("language") || "en";
+            this.language = this.element.data("language") || "en";
             this.isFrench = this.language.includes("fr");
             this.language = this.isFrench ? "fr" : "en";
             this.usingRefinedSuggestions = false;
+            this.fieldLine1    = this.element.data('field-line1')    || 'addressLine1';
+            this.fieldLine2    = this.element.data('field-line2')    || 'addressLine2';
+            this.fieldCity     = this.element.data('field-city')     || 'city';
+            this.fieldProvince = this.element.data('field-province') || 'province';
+            this.fieldPostalCode = this.element.data('field-postal-code') || 'postalCode';
 
             if (!this.host) {
                 console.error("Invalid Canada Post HOST...")
@@ -32,14 +49,9 @@
                 datumTokenizer: Bloodhound.tokenizers.whitespace,
                 queryTokenizer: Bloodhound.tokenizers.whitespace
             });
-            this.widget = this.getWidget();
+            this.widget = $(input);
             this.initTypeahead(this.addressEngine);
             this.addEventListeners();
-        }
-
-        // returns input field
-        getWidget() {
-            return $(this.element).find(AddressInput.selectors.widget).get(0);
         }
 
         // returns API url
@@ -49,25 +61,25 @@
             let limit = params && params.limit;
 
             let url = this.host + "/addresscomplete/interactive/find/v2.10/json3.ws?";
-                url += "Key=" + this.key;
-                url += "&SearchTerm=" + (text || '%QUERY');
-                url += "&LastId=" + (id || '');
-                url += "&SearchFor=";
-                url += "&Country=CAN";
-                url += "&LanguagePreference=" + (this.language || 'en');
-                url += "&MaxSuggestions=" + (limit || '');
-                url += "&MaxResults=";
-                url += "&Origin=";
-                url += "&Bias=";
-                url += "&Filter=";
-                url += "&GeoFence=";
+            url += "Key=" + this.key;
+            url += "&SearchTerm=" + (text || '%QUERY');
+            url += "&LastId=" + (id || '');
+            url += "&SearchFor=";
+            url += "&Country=CAN";
+            url += "&LanguagePreference=" + (this.language || 'en');
+            url += "&MaxSuggestions=" + (limit || '');
+            url += "&MaxResults=";
+            url += "&Origin=";
+            url += "&Bias=";
+            url += "&Filter=";
+            url += "&GeoFence=";
             return url;
         }
 
         // instantiating typeahead library with configuration
         initTypeahead(sourceEngine) {
-            $(this.widget).typeahead('destroy');
-            $(this.widget).typeahead(
+            this.widget.typeahead('destroy');
+            this.widget.typeahead(
                 {
                     hint: false,
                     highlight: true,
@@ -96,7 +108,7 @@
         addEventListeners() {
             const self = this;
 
-            $(this.widget).on('typeahead:select', function(e, suggestion) {
+            this.widget.on('typeahead:select', function(e, suggestion) {
                 e.stopPropagation();
                 e.stopImmediatePropagation();
 
@@ -116,8 +128,8 @@
                             self.initTypeahead(function(query, syncResults, asyncResults) {
                                 syncResults(newSuggestions);
                             });
-                            $(self.widget).typeahead('val', suggestion.Text);
-                            $(self.widget).focus();
+                            self.widget.typeahead('val', suggestion.Text);
+                            self.widget.focus();
                             self.usingRefinedSuggestions = true;
                         },
                         error: function() {
@@ -145,12 +157,13 @@
                                 address = items[0];
                             }
                             self.limit = self.fixedLimit;
-                            $(self.container).find('[data-name="address2"]').val(address.Line2).blur();
-                            $(self.container).find('[data-name="city"]').val(address.City).blur();
-                            $(self.container).find('[data-name="province"]').val(address.ProvinceCode).blur();
-                            $(self.container).find('[data-name="postalCode"]').val(address.PostalCode).blur();
-                            $(self.widget).val(address.Line1);
-                            $(self.widget).blur();
+                            self.container.find('.' + self.fieldLine1).find('input').val(address.Line1).blur();
+                            self.container.find('.' + self.fieldLine2).find('input').val(address.Line2).blur();
+                            self.container.find('.' + self.fieldCity).find('input').val(address.City).blur();
+                            self.container.find('.' + self.fieldProvince).find('input').val(address.ProvinceCode).blur();
+                            self.container.find('.' + self.fieldPostalCode).find('input').val(address.PostalCode).blur();
+                            self.widget.val(address.Line1);
+                            self.widget.blur();
                         },
                         error: function() {
                             console.log('Unable to find selected address...');
@@ -159,8 +172,8 @@
                 }
             });
 
-            // resets input fields when interaction is completed
-            $(this.widget).on('blur', function() {
+            // resets typeahead source after drilling into a multi-address result
+            this.widget.on('blur', function() {
                 if (self.usingRefinedSuggestions) {
                     self.usingRefinedSuggestions = false;
                     self.limit = self.fixedLimit;
@@ -170,11 +183,23 @@
         }
     }
 
-    $(document).ready(function() {
-        $("[data-cmp-is='adaptiveFormAddressInput']").each(function() {
-            let $element = $(this);
-            let formContainer = $element.closest('.panel').get(0) || $element.closest('.rootPanel').get(0) || null;
-            new AddressInput({ element: $element.get(0), formContainer: formContainer });
+    window.AddressInput = AddressInput;
+
+    // Initialize inputs already in the DOM.
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function() { initAll(); });
+    } else {
+        initAll();
+    }
+
+    // Re-initialize whenever a new panel instance is added to a repeatable panel.
+    new MutationObserver(function(mutations) {
+        mutations.forEach(function(mutation) {
+            mutation.addedNodes.forEach(function(node) {
+                if (node.nodeType === Node.ELEMENT_NODE) {
+                    initAll(node);
+                }
+            });
         });
-    });
+    }).observe(document.body, { childList: true, subtree: true });
 })();

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/address/widget.html
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/address/widget.html
@@ -2,10 +2,6 @@
 <sly data-sly-use.guideConstants="com.adobe.aemds.guide.utils.GuideConstants"/>
 <sly data-sly-use.guideField="com.adobe.aemds.guide.common.GuideTextBox"/>
 <sly data-sly-use.canadaPost="ca.yukon.aem.core.models.AddressModel"/>
-<sly data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html"
-     data-sly-call="${clientlib.css @ categories='yukon-forms.components'}"/>
-<sly data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html"
-     data-sly-call="${clientlib.js @ categories='yukon-forms.components'}"/>
 
 <div class="${guideConstants.GUIDE_FIELD_WIDGET} textField ${guideField.multiLine ? 'multiline' : ''}
             ${guideField.allowRichText ? 'richText' : ''} address_container"

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/address/widget.html
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/address/widget.html
@@ -2,6 +2,10 @@
 <sly data-sly-use.guideConstants="com.adobe.aemds.guide.utils.GuideConstants"/>
 <sly data-sly-use.guideField="com.adobe.aemds.guide.common.GuideTextBox"/>
 <sly data-sly-use.canadaPost="ca.yukon.aem.core.models.AddressModel"/>
+<sly data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html"
+     data-sly-call="${clientlib.css @ categories='yukon-forms.components'}"/>
+<sly data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html"
+     data-sly-call="${clientlib.js @ categories='yukon-forms.components'}"/>
 
 <div class="${guideConstants.GUIDE_FIELD_WIDGET} textField ${guideField.multiLine ? 'multiline' : ''}
             ${guideField.allowRichText ? 'richText' : ''} address_container"
@@ -10,6 +14,11 @@
      data-host="${canadaPost.host}"
      data-limit="${canadaPost.limit}"
      data-language="${currentPage.language}"
+     data-field-line1="${canadaPost.fieldLine1}"
+     data-field-line2="${canadaPost.fieldLine2}"
+     data-field-city="${canadaPost.fieldCity}"
+     data-field-province="${canadaPost.fieldProvince}"
+     data-field-postal-code="${canadaPost.fieldPostalCode}"
 
      style="${guideField.styles @ context='scriptString'}">
     <sly data-sly-test="${guideField.allowRichText}">


### PR DESCRIPTION
Usage:

1. Add a panel.
2. Drag the Canada Post API Address component into the panel and name it addressLine1.
3. In the same panel, add separate Text Box fields for address line 2, city, province, and postal code, named addressLine2, city, province, and postalCode respectively.
4. Open the address component's dialog and, on the Canada Post tab, point it to custom field names if the defaults above don't suit your form.
5. Make sure the form's client library category includes "yukon-forms.components"