### PR TITLE
eServices - Helper functions and focus after scribble signatures (production)

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-utils/js.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-utils/js.txt
@@ -1,3 +1,5 @@
 #base=js
 
 repeatableHelpers.js
+choiceFieldHelpers.js
+dateFieldHelpers.js

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-utils/js/choiceFieldHelpers.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-utils/js/choiceFieldHelpers.js
@@ -1,0 +1,11 @@
+/** Returns an array with one option for choice fields (radio buttons or checkboxes). Used to set the options of such fields in AEM's rules.
+ *
+@name createChoiceFieldOption Creates an array from a value and a display value
+@param {string} value Value of the option (on Author, it's the value before the '=' sign)
+@param {string} displayValue Display value of the option (on Author, it's the value after the '=' sign)
+@return {string[]} An array with the new option
+ */
+function createChoiceFieldOption(value, displayValue) {
+	return [value + "=" + displayValue];
+}
+

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-utils/js/dateFieldHelpers.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-utils/js/dateFieldHelpers.js
@@ -1,0 +1,15 @@
+/** Extracts the display value of a date field
+ *
+@name getDateDisplayValue
+@param {string} SOM expression of the date field to extract display value from
+@return {string} The display value of the date field
+ */
+function getDateDisplayValue(dateFieldSOM) {
+	var dateField = window.guideBridge.resolveNode(dateFieldSOM);
+	if (!dateField) {
+		console.debug("Date field not found. Returning empty string as display value.");
+		return "";
+	}
+	return dateField.formattedValue;
+}
+

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/js/triggerPerPanelValidation.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/js/triggerPerPanelValidation.js
@@ -258,13 +258,13 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 /**
- * Ensures that focus is set to the next item when the user uses the scribble signature field.
+ * Ensures that focus stays on the scribble signature field when the user uses it.
  */
 document.addEventListener('DOMContentLoaded', function() {
         window.guideBridge.on("elementValueChanged", function(event, payload) {
                 if (payload.target.className === "guideScribble") {
-                        console.debug("Target was a scribble signature field. Setting focus to next item in the panel.");
-                        window.guideBridge.setFocus(payload.target.parent.navigationContext.nextItem);
+                        console.debug("Target was a scribble signature field. Setting focus to it again.");
+                        window.guideBridge.setFocus(payload.target);
                 }
         });
 });


### PR DESCRIPTION
Adds functions to:
* return an array from two strings (useful for setting the options of checkboxes and radio buttons)
* return the display value of dates (such that we can use them in custom strings)

Additionally, keeps the focus on scribble signature components after the user is done signing. That is the standard behaviour of other fields and prevents issues when the signature is the last field on a panel.