### PR TITLE
add custom file attachment component

### DIFF
--- a/core/src/main/java/ca/yukon/aem/core/models/CustomGuideFileUpload.java
+++ b/core/src/main/java/ca/yukon/aem/core/models/CustomGuideFileUpload.java
@@ -1,0 +1,22 @@
+package ca.yukon.aem.core.models;
+
+import com.adobe.aemds.guide.common.GuideFileUpload;
+
+public class CustomGuideFileUpload extends GuideFileUpload {
+
+    public CustomGuideFileUpload() {
+    }
+
+    public String getFileNamePattern() {
+        return this.resourceProps.get("fileNamePattern", String.class);
+    }
+
+    public String getFileNamePatternMessage() {
+        return this.resourceProps.get("fileNamePatternMessage", String.class);
+    }
+
+    public String getShowAlertMessage() {
+        Boolean value = this.resourceProps.get("showAlertMessage", Boolean.class);
+        return value != null && value ? "true" : "false";
+    }
+}

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/customfileupload/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/customfileupload/.content.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Custom File Upload component.
+
+  Extends the out-of-the-box AEM Forms Foundation File Upload component and
+  adds two configurable dialog properties:
+
+    fileNamePattern        — regex pattern string for invalid characters
+                             e.g.  [<>:"/\\|?*\x00-\x1F]
+                             Leave blank to use the built-in default.
+
+    fileNamePatternMessage — error message shown when validation fails.
+                             Leave blank to use the built-in default.
+
+  Deploy to:
+    ui.apps/src/main/content/jcr_root/apps/<yourproject>/components/form/customfileupload/
+-->
+<jcr:root
+  xmlns:jcr="http://www.jcp.org/jcr/1.0"
+  xmlns:cq="http://www.day.com/jcr/cq/1.0"
+  xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+  jcr:primaryType="cq:Component"
+  jcr:title="File Attachment (Custom)"
+  jcr:description="File upload with configurable file name validation."
+  sling:resourceSuperType="fd/af/components/guidefileupload"
+  componentGroup="Adaptive Form" />

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/customfileupload/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/customfileupload/_cq_dialog/.content.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
+          xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+          jcr:primaryType="nt:unstructured"
+          jcr:title="\0"
+          sling:resourceType="cq/gui/components/authoring/dialog">
+    <content
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/coral/foundation/container">
+        <items jcr:primaryType="nt:unstructured">
+            <accordion
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/coral/foundation/accordion">
+                <items jcr:primaryType="nt:unstructured">
+                    <basic
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Basic"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"/>
+                    <help
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Help Content"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"/>
+                    <accessibility jcr:primaryType="nt:unstructured"/>
+                    <patterns
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"/>
+                    <validation
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Validation"
+                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                        <items jcr:primaryType="nt:unstructured">
+                            <fileNamePattern
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                fieldLabel="Invalid Characters Pattern"
+                                fieldDescription="Regex pattern matching characters that are NOT allowed in file names. Leave blank to use the default pattern which blocks: &lt; &gt; : &quot; / \ | ? * and control characters."
+                                name="./fileNamePattern"
+                                emptyText='e.g. [&lt;&gt;:"/\\|?*]'/>
+                            <fileNamePatternMessage
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                fieldLabel="Validation Error Message"
+                                fieldDescription="Message shown when a file name fails validation. Leave blank to use the default message which lists the offending file names."
+                                name="./fileNamePatternMessage"
+                                emptyText="e.g. File name contains unsupported characters."/>
+                            <showAlertMessage
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                text="Show Alert Message"
+                                fieldDescription="When enabled, displays a browser alert when a file name fails validation. Disable if you prefer to suppress the alert and handle feedback through other means."
+                                name="./showAlertMessage"
+                                value="{Boolean}true"
+                                uncheckedValue="{Boolean}false"/>
+                        </items>
+                    </validation>
+                </items>
+            </accordion>
+        </items>
+    </content>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/customfileupload/_cq_template/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/customfileupload/_cq_template/.content.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
+    jcr:primaryType="nt:unstructured"
+    jcr:title="File Attachment"
+    buttonText="Attach"
+    dorExclusion="true"
+    guideNodeClass="guideFileUpload"
+    mimeType="[audio/*, video/*, image/*, text/*, application/pdf]">
+    <items jcr:primaryType="nt:unstructured">
+        <fileattachment
+            jcr:primaryType="nt:unstructured"
+            guideNodeClass="guideCompositeFieldItem"
+            name="fileAttachment"/>
+        <comment
+            jcr:primaryType="nt:unstructured"
+            guideNodeClass="guideCompositeFieldItem"
+            name="comment"/>
+    </items>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/customfileupload/clientlibs/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/customfileupload/clientlibs/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    categories="[yukon-forms.components]"
+    dependencies="[fd.af.view.foundation]"
+    allowProxy="{Boolean}true" />

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/customfileupload/clientlibs/js.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/customfileupload/clientlibs/js.txt
@@ -1,0 +1,2 @@
+#base=js
+customfileupload.js

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/customfileupload/clientlibs/js/customfileupload.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/customfileupload/clientlibs/js/customfileupload.js
@@ -109,10 +109,10 @@
 
           var pattern = $(this).data("fileNamePattern");
           var message = $(this).data("fileNamePatternMessage");
-          var showErrorMessage = $(this).data("showAlertMessage") !== "true";
+          var showErrorMessageInline = $(this).data("showAlertMessage") !== "true";
 
-          if (pattern || message || showErrorMessage) {
-            patchInstance(widget, pattern, message, showErrorMessage, $(this).closest('.guideFileUpload').find('.guideFieldError'));
+          if (pattern || message || showErrorMessageInline) {
+            patchInstance(widget, pattern, message, showErrorMessageInline, $(this).closest('.guideFileUpload').find('.guideFieldError'));
             $(this).data("customFileUploadPatched", true);
           }
         } catch (e) {

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/customfileupload/clientlibs/js/customfileupload.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/customfileupload/clientlibs/js/customfileupload.js
@@ -1,0 +1,189 @@
+/**
+ * customfileupload.js
+ *
+ * Overrides isValid and invalidMessage on individual AdobeFileAttachment
+ * widget instances whose field model carries fileNamePattern / fileNamePatternMessage.
+ *
+ * AdobeFileAttachment is defined inside an IIFE in xfalibWidgets.js so its
+ * prototype is not accessible globally. Instead we override the two methods
+ * as own properties on each matching instance — own properties shadow prototype
+ * methods in the normal JS prototype chain lookup.
+ *
+ * Widget instance is retrieved via:  $(input).data('adobeFileAttachment')
+ */
+(function (window, $) {
+  "use strict";
+
+  var LOG = "[CustomFileUpload] ";
+
+  // ── Default validation (mirrors original AdobeFileAttachment.isValid) ──────
+  var DEFAULT_RG1 = /^[^\\/:\*\;\$\%\?"<>\|]+$/;
+  var DEFAULT_RG2 = /^\./;
+  var DEFAULT_RG3 = /^(nul|prn|con|lpt[0-9]|com[0-9])(\.|$)/i;
+
+  function defaultIsValid(fname) {
+    return DEFAULT_RG1.test(fname) && !DEFAULT_RG2.test(fname) && !DEFAULT_RG3.test(fname);
+  }
+
+  function buildRegex(patternStr) {
+    if (patternStr && patternStr.trim()) {
+      try {
+        return new RegExp(patternStr.trim());
+      } catch (e) {
+        console.warn(LOG + "Invalid regex '" + patternStr + "' — using default.", e);
+      }
+    }
+    return null;
+  }
+
+  // ── Patch one widget instance ─────────────────────────────────────────────
+  function patchInstance(widget, patternStr, messageStr, showErrorMessage, errorMessageContainer) {
+    try {
+      var customRegex   = buildRegex(patternStr);
+      var customMessage = (messageStr && messageStr.trim()) ? messageStr.trim() : null;
+
+      // Own-property assignment shadows AdobeFileAttachment.prototype.isValid
+      widget.isValid = function (fname) {
+        try {
+          errorMessageContainer.html('');
+          if (customRegex) {
+            return !customRegex.test(fname) && !DEFAULT_RG2.test(fname);
+          }
+          return defaultIsValid(fname);
+        } catch (e) {
+          console.error(LOG + "Error in custom isValid — accepting file.", e);
+          return true;
+        }
+      };
+
+      // Only override invalidMessage when a custom message is configured.
+      // SIZE and MIMETYPE branches fall through to original locale strings.
+      if (customMessage || showErrorMessage) {
+        widget.invalidMessage = function (refObj, fileName, invalidFeature) {
+          var message = '';
+          var strings = xfalib.locale.Strings;
+          var loc = xfalib.ut.LocalizationUtil.prototype;
+          try {
+            if (invalidFeature === refObj.invalidFeature.NAME) {
+              if (customMessage) {
+                message = customMessage.replace("{fileName}", fileName);
+              } else {
+                message = loc.getLocalizedMessage("", strings["FileNameInvalid"], [fileName]);
+              }
+            } else {
+              if (invalidFeature === refObj.invalidFeature.SIZE) {
+                message = loc.getLocalizedMessage("", strings["FileSizeGreater"], [fileName, refObj.options.fileSizeLimit]);
+              } else if (invalidFeature === refObj.invalidFeature.MIMETYPE) {
+                message = loc.getLocalizedMessage("", strings["FileMimeTypeInvalid"], [fileName]);
+              }
+            }
+          } catch (e) {
+            message = LOG + "Error in custom invalidMessage.";
+            console.error(LOG + "Error in custom invalidMessage.", e);
+          }
+          if (showErrorMessage) {
+            errorMessageContainer.css("visibility", message ? "visible" : "hidden");
+            errorMessageContainer.html(message);
+          } else {
+            alert(message);
+          }
+        };
+      }
+
+      console.log(LOG + "Instance patched — pattern: " + (patternStr || "(default)"));
+    } catch (e) {
+      console.error(LOG + "Failed to patch instance.", e);
+    }
+  }
+
+  // ── Find and patch all relevant file inputs ───────────────────────────────
+  function processInputs() {
+    try {
+      $("input[type='file']").each(function () {
+        try {
+          // Guard against double-patching when processInputs reruns for a new panel instance
+          if ($(this).data("customFileUploadPatched")) return;
+
+          var widget = $(this).data("adobeFileAttachment");
+          if (!widget) return;
+
+          var pattern = $(this).data("fileNamePattern");
+          var message = $(this).data("fileNamePatternMessage");
+          var showErrorMessage = $(this).data("showAlertMessage") !== "true";
+
+          if (pattern || message || showErrorMessage) {
+            patchInstance(widget, pattern, message, showErrorMessage, $(this).closest('.guideFileUpload').find('.guideFieldError'));
+            $(this).data("customFileUploadPatched", true);
+          }
+        } catch (e) {
+          console.warn(LOG + "Error processing input.", e);
+        }
+      });
+    } catch (e) {
+      console.error(LOG + "Error in processInputs.", e);
+    }
+  }
+
+  // ── Initialisation ────────────────────────────────────────────────────────
+  function onBridgeReady(guideBridge) {
+    try {
+      guideBridge.connect(function () {
+        try {
+          processInputs();
+        } catch (e) {
+          console.error(LOG + "Error after guideBridge.connect().", e);
+        }
+      });
+    } catch (e) {
+      console.error(LOG + "guideBridge.connect() failed.", e);
+    }
+  }
+
+  function init() {
+    try {
+      if (window.guideBridge &&
+          typeof window.guideBridge.isConnected === "function" &&
+          window.guideBridge.isConnected()) {
+        onBridgeReady(window.guideBridge);
+      } else {
+        window.addEventListener("bridgeInitializeStart", function (e) {
+          try {
+            var gb = (e.detail && e.detail.guideBridge)
+                ? e.detail.guideBridge : window.guideBridge;
+            if (gb) onBridgeReady(gb);
+          } catch (e2) {
+            console.error(LOG + "Error in bridgeInitializeStart handler.", e2);
+          }
+        });
+      }
+    } catch (e) {
+      console.error(LOG + "Error in init().", e);
+    }
+  }
+
+  try {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", function () {
+        try { init(); } catch (e) { console.error(LOG + "DOMContentLoaded error.", e); }
+      });
+    } else {
+      init();
+    }
+  } catch (e) {
+    console.error(LOG + "Top-level init error — custom validation disabled.", e);
+  }
+
+  // Re-patch whenever new nodes land in the DOM (repeatable panels).
+  // adobeFileAttachment may not be set yet on the first mutation — the guard
+  // in processInputs skips those inputs, and Foundation's own subsequent DOM
+  // writes will trigger another callback that picks them up.
+  new MutationObserver(function (mutations) {
+    var hasNewNodes = mutations.some(function (m) {
+      return m.addedNodes.length > 0;
+    });
+    if (hasNewNodes) {
+      try { processInputs(); } catch (e) { console.error(LOG + "MutationObserver error.", e); }
+    }
+  }).observe(document.body, { childList: true, subtree: true });
+
+}(window, jQuery));

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/customfileupload/clientlibs/js/customfileupload.js
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/customfileupload/clientlibs/js/customfileupload.js
@@ -83,7 +83,7 @@
           }
           if (showErrorMessage) {
             errorMessageContainer.css("visibility", message ? "visible" : "hidden");
-            errorMessageContainer.html(message);
+            errorMessageContainer.text(message);
           } else {
             alert(message);
           }

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/customfileupload/init.jsp
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/customfileupload/init.jsp
@@ -1,0 +1,20 @@
+<%------------------------------------------------------------------------
+ ~
+ ~ ADOBE CONFIDENTIAL
+ ~ __________________
+ ~
+ ~  Copyright 2014 Adobe Systems Incorporated
+ ~  All Rights Reserved.
+ ~
+ ~ NOTICE:  All information contained herein is, and remains
+ ~ the property of Adobe Systems Incorporated and its suppliers,
+ ~ if any.  The intellectual and technical concepts contained
+ ~ herein are proprietary to Adobe Systems Incorporated and its
+ ~ suppliers and may be covered by U.S. and Foreign Patents,
+ ~ patents in process, and are protected by trade secret or copyright law.
+ ~ Dissemination of this information or reproduction of this material
+ ~ is strictly forbidden unless prior written permission is obtained
+ ~ from Adobe Systems Incorporated.
+ --------------------------------------------------------------------------%>
+<%@include file="/libs/fd/af/components/guidesglobal.jsp"%>
+<guide:initializeBean name="guideField" className="ca.yukon.aem.core.models.CustomGuideFileUpload"/>

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/customfileupload/widget.jsp
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/customfileupload/widget.jsp
@@ -1,0 +1,42 @@
+<%------------------------------------------------------------------------
+ ~
+ ~ ADOBE CONFIDENTIAL
+ ~ __________________
+ ~
+ ~  Copyright 2014 Adobe Systems Incorporated
+ ~  All Rights Reserved.
+ ~
+ ~ NOTICE:  All information contained herein is, and remains
+ ~ the property of Adobe Systems Incorporated and its suppliers,
+ ~ if any.  The intellectual and technical concepts contained
+ ~ herein are proprietary to Adobe Systems Incorporated and its
+ ~ suppliers and may be covered by U.S. and Foreign Patents,
+ ~ patents in process, and are protected by trade secret or copyright law.
+ ~ Dissemination of this information or reproduction of this material
+ ~ is strictly forbidden unless prior written permission is obtained
+ ~ from Adobe Systems Incorporated.
+ --------------------------------------------------------------------------%>
+<%--
+ File Upload Component
+--%>
+<%@include file="/libs/fd/af/components/guidesglobal.jsp"%>
+<%@ page import="com.adobe.granite.toggle.api.ToggleRouter,
+                 com.adobe.aemds.guide.fdfl.utils.FeatureToggleConstants" %>
+<%
+    ToggleRouter toggleRouter = sling.getService(ToggleRouter.class);
+    boolean isDoubleExtFTEnabled = toggleRouter != null && toggleRouter.isEnabled(FeatureToggleConstants.FT_DISABLE_DOUBLE_EXTENSION_FILES);
+    pageContext.setAttribute("isDoubleExtFTEnabled", isDoubleExtFTEnabled);
+%>
+<div class="<%= GuideConstants.GUIDE_FIELD_WIDGET%> afFileUpload"
+     <c:if test="${isDoubleExtFTEnabled}">data-disable-double-extension-files="${guideField.disableDoubleExtensionFiles}"</c:if>
+     style="${guide:encodeForHtmlAttr(guideField.styles,xssAPI)}">
+    <input id="${guide:encodeForHtmlAttr(guideid,xssAPI)}${'_widget'}"  name="${guide:encodeForHtmlAttr(guideField.name,xssAPI)}" type="file" 
+           accept="${guide:encodeForHtmlAttr(guideField.mimeType,xssAPI)}" tabindex="-1" style="" aria-describedby="${guide:encodeForHtmlAttr(guideField.labelForId,xssAPI)}_desc"
+           data-file-name-pattern="${guideField.fileNamePattern}"
+           data-file-name-pattern-message="${guideField.fileNamePatternMessage}"
+           data-show-alert-message="${guideField.showAlertMessage}"
+           <c:if test="${guideField.multiSelection}"> multiple</c:if>/>
+    <button class="button-default button-medium guide-fu-attach-button" type="button" style="${guide:encodeForHtmlAttr(guideField.widgetInlineStyles,xssAPI)}" 
+            aria-labelledby="${guide:encodeForHtmlAttr(guideField.labelForId,xssAPI)}_desc">${guide:encodeForHtmlAttr(guideField.buttonText,xssAPI)}</button>
+    <ul class="guide-fu-fileItemList"></ul>
+</div>

--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/customfileupload/widget.jsp
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/components/adaptiveForm/customfileupload/widget.jsp
@@ -32,9 +32,9 @@
      style="${guide:encodeForHtmlAttr(guideField.styles,xssAPI)}">
     <input id="${guide:encodeForHtmlAttr(guideid,xssAPI)}${'_widget'}"  name="${guide:encodeForHtmlAttr(guideField.name,xssAPI)}" type="file" 
            accept="${guide:encodeForHtmlAttr(guideField.mimeType,xssAPI)}" tabindex="-1" style="" aria-describedby="${guide:encodeForHtmlAttr(guideField.labelForId,xssAPI)}_desc"
-           data-file-name-pattern="${guideField.fileNamePattern}"
-           data-file-name-pattern-message="${guideField.fileNamePatternMessage}"
-           data-show-alert-message="${guideField.showAlertMessage}"
+           data-file-name-pattern="${guide:encodeForHtmlAttr(guideField.fileNamePattern,xssAPI)}"
+           data-file-name-pattern-message="${guide:encodeForHtmlAttr(guideField.fileNamePatternMessage,xssAPI)}"
+           data-show-alert-message="${guide:encodeForHtmlAttr(guideField.showAlertMessage,xssAPI)}"
            <c:if test="${guideField.multiSelection}"> multiple</c:if>/>
     <button class="button-default button-medium guide-fu-attach-button" type="button" style="${guide:encodeForHtmlAttr(guideField.widgetInlineStyles,xssAPI)}" 
             aria-labelledby="${guide:encodeForHtmlAttr(guideField.labelForId,xssAPI)}_desc">${guide:encodeForHtmlAttr(guideField.buttonText,xssAPI)}</button>


### PR DESCRIPTION
**Technical notes:** 

- Extends fd/af/components/guidefileupload — inherits all standard file upload behaviour (MIME type filtering, file size limits, multiple selection, DOR exclusion).
  - Validation is applied by patching the isValid and invalidMessage methods directly on each AdobeFileAttachment widget instance at runtime, so built-in size and MIME-type errors continue to use AEM's own locale strings.
  - The MutationObserver in customfileupload.js re-runs patching whenever new DOM nodes appear, which covers repeatable panel instances added after initial load.

**Usage**

Authoring dialog — Validation tab
 
- Invalid Characters Pattern: A JavaScript regex pattern matching characters that should be rejected.
- Validation Error Message: Message shown when a file name fails the pattern check. Use {fileName} as a placeholder for the offending file name.
- Show Alert Message: When checked, validation errors appear as a browser alert(). When unchecked (default), errors appear inline below the field.
