### PR TITLE
eServices - Add styling classes for placing help icons next to labels

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/less/style.less
+++ b/ui.apps/src/main/content/jcr_root/apps/yukon-forms/clientlibs/clientlib-yukon/less/style.less
@@ -38,3 +38,18 @@ ul.tab-navigators-vertical > li:focus-visible {
 	position: relative;
 }
 
+.helpAnchor label {
+	display: inline-block;
+	anchor-name: --label-anchor;
+}
+
+.helpAnchor .guideHelpQuestionMark, .helpAnchorCheckBox .guideHelpQuestionMark {
+	position-anchor: --label-anchor;
+	left: anchor(right);
+}
+
+.helpAnchorCheckBox .guideCheckBoxItem label {
+	display: inline-block;
+	anchor-name: --label-anchor;
+}
+


### PR DESCRIPTION
Currently, help icons are sometimes placed far to the right of field labels, which may not make it immediately clear to the user that they are related to the field in question. This PR adds two classes (one for most fields, and another one for single-item checkboxes wherein the label needs to be placed next to the item label), such that, when assigned to fields, place the help icon next to the label.

<img width="421" height="190" alt="image" src="https://github.com/user-attachments/assets/df415847-69c8-4b90-aa3c-ff1e1745aefa" />
